### PR TITLE
ci: github: qa-integration no pwm and i2c tests

### DIFF
--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -83,9 +83,7 @@ jobs:
             --testcase-root zephyr/tests/drivers/entropy \
             --testcase-root zephyr/tests/drivers/hwinfo \
             --testcase-root zephyr/tests/drivers/gpio \
-            --testcase-root zephyr/tests/drivers/pwm \
             --testcase-root zephyr/tests/drivers/spi \
-            --testcase-root zephyr/tests/drivers/i2c \
             --testcase-root zephyr/tests/drivers/can
         continue-on-error: true
 


### PR DESCRIPTION
disable:

- STM32F7: PWM loopback test fails
- STM32F7: I2C loopback test fails