### PR TITLE
Take over from Li-Pro.Net to TiaC Systems -- Addendum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Kconfig.bridle
+++ b/Kconfig.bridle
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Li-Pro.Net bridle to embedded environment
+# Bridle for embedded systems based on Zephyr
 
 **NOT FOR PRODUCT DEVELOPMENT**
 
@@ -52,7 +52,7 @@ rm -rf build/bridle-doc
 west build --cmake-only -b none -d build/bridle-doc bridle/doc
 ```
 
-Build the complete Li-Pro.Net bridle HTML pages in
+Build the complete Bridle HTML pages in
 ``build/bridle-doc/html``, type in:
 
 ```bash
@@ -84,7 +84,7 @@ set separately, complete the following steps:
    west build -t zephyr -b none -d build/bridle-doc
    ```
 
-4. Build Li-Pro.Net bridle HTML pages in
+4. Build Bridle HTML pages in
    ``build/bridle-doc/html/bridle``, type in:
 
    ```bash
@@ -539,9 +539,9 @@ After this we will stay inside our working directory ``workspace``, have the
 ```
 
 As well we will found the Zephyr core source code in the ``zephyr`` folder
-and the Li-Pro.Net bridle source code in the ``bridle`` folder. To complete
-the setup, we need to extend our Python virtual environment with all the
-packages that are required by Zephyr and Li-Pro.Net bridle itself, type in:
+and the Bridle source code in the ``bridle`` folder. To complete the setup,
+we need to extend our Python virtual environment with all the packages that
+are required by Zephyr and Bridle itself, type in:
 
 ```bash
 pip install --upgrade --requirement zephyr/scripts/requirements.txt

--- a/boards/arm/tiac_magpie/Kconfig.board
+++ b/boards/arm/tiac_magpie/Kconfig.board
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/arm/tiac_magpie/Kconfig.defconfig
+++ b/boards/arm/tiac_magpie/Kconfig.defconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/arm/tiac_magpie/board.cmake
+++ b/boards/arm/tiac_magpie/board.cmake
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/arm/tiac_magpie/tiac_magpie.dts
+++ b/boards/arm/tiac_magpie/tiac_magpie.dts
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/arm/tiac_magpie/tiac_magpie_defconfig
+++ b/boards/arm/tiac_magpie/tiac_magpie_defconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/arm/tiac_magpie/tiac_magpie_pin_header.dtsi
+++ b/boards/arm/tiac_magpie/tiac_magpie_pin_header.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/shields/loopback_test/Kconfig.defconfig
+++ b/boards/shields/loopback_test/Kconfig.defconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/shields/loopback_test/Kconfig.shield
+++ b/boards/shields/loopback_test/Kconfig.shield
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/shields/loopback_test/boards/tiac_magpie.conf
+++ b/boards/shields/loopback_test/boards/tiac_magpie.conf
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/shields/loopback_test/boards/tiac_magpie.defconfig
+++ b/boards/shields/loopback_test/boards/tiac_magpie.defconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/shields/loopback_test/boards/tiac_magpie.overlay
+++ b/boards/shields/loopback_test/boards/tiac_magpie.overlay
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/shields/loopback_test/loopback_test.overlay
+++ b/boards/shields/loopback_test/loopback_test.overlay
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/shields/loopback_test/loopback_test_tmph.overlay
+++ b/boards/shields/loopback_test/loopback_test_tmph.overlay
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/shields/loopback_test/tests/i2c_slave_api.defconfig
+++ b/boards/shields/loopback_test/tests/i2c_slave_api.defconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/shields/loopback_test/tests/spi_loopback.defconfig
+++ b/boards/shields/loopback_test/tests/spi_loopback.defconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # Copyright (c) 2019-2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause

--- a/doc/bridle/index.rst
+++ b/doc/bridle/index.rst
@@ -54,7 +54,7 @@ system (RTOS), which is built for **connected low power products** and
      <li class="grid-item">
        <a href="samples.html">
          <span class="grid-icon fa fa-cogs"></span>
-         <h2>Samples and Demos</h2>
+         <h2>Samples & Demos</h2>
        </a>
        <p>A list of samples and demos that can run on a variety of boards supported
           by Bridle and Zephyr</p>
@@ -69,7 +69,7 @@ system (RTOS), which is built for **connected low power products** and
      <li class="grid-item">
        <a href="dm_adding_code.html">
          <span class="grid-icon fa fa-github"></span>
-         <h2>Contribution Guidelines</h2>
+         <h2>Contribution</h2>
        </a>
        <p>As an open-source project, we welcome and encourage the community
           to submit patches directly to Bridle.</p>

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/dts/arm/st/f7/stm32f7-adc123.dtsi
+++ b/dts/arm/st/f7/stm32f7-adc123.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/dts/arm/st/f7/stm32f7-can2.dtsi
+++ b/dts/arm/st/f7/stm32f7-can2.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/dts/arm/st/f7/stm32f7-can3.dtsi
+++ b/dts/arm/st/f7/stm32f7-can3.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/dts/arm/st/f7/stm32f777.dtsi
+++ b/dts/arm/st/f7/stm32f777.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/dts/arm/st/f7/stm32f777Xi.dtsi
+++ b/dts/arm/st/f7/stm32f777Xi.dtsi
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/dts/bindings/tiac-magpie-pin-header.yaml
+++ b/dts/bindings/tiac-magpie-pin-header.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/commands/CMakeLists.txt
+++ b/lib/commands/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/commands/Kconfig
+++ b/lib/commands/Kconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lib/commands/cmd_hello.c
+++ b/lib/commands/cmd_hello.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2019-2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/samples/helloshell/CMakeLists.txt
+++ b/samples/helloshell/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/samples/helloshell/boards/native_posix.conf
+++ b/samples/helloshell/boards/native_posix.conf
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2019-2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
+
 # disable unsupported components
 CONFIG_ADC=n
 CONFIG_ADC_SHELL=n

--- a/samples/helloshell/boards/qemu_cortex_m3.conf
+++ b/samples/helloshell/boards/qemu_cortex_m3.conf
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2019-2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
+
 # disable unsupported components
 CONFIG_ADC=n
 CONFIG_ADC_SHELL=n

--- a/samples/helloshell/boards/qemu_x86.conf
+++ b/samples/helloshell/boards/qemu_x86.conf
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2019-2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
+
 # disable unsupported components
 CONFIG_ADC=n
 CONFIG_ADC_SHELL=n

--- a/samples/helloshell/prj-minimal.conf
+++ b/samples/helloshell/prj-minimal.conf
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2019-2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-threaded, with timer support in the kernel
 CONFIG_MULTITHREADING=y
 CONFIG_NUM_COOP_PRIORITIES=16

--- a/samples/helloshell/prj.conf
+++ b/samples/helloshell/prj.conf
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2019-2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-threaded, with timer support in the kernel
 CONFIG_MULTITHREADING=y
 CONFIG_NUM_COOP_PRIORITIES=16

--- a/samples/helloshell/src/main.c
+++ b/samples/helloshell/src/main.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 TiaC Systems
  * Copyright (c) 2019-2021 Li-Pro.Net
  * Copyright (c) 2012-2014 Wind River Systems, Inc.
  * SPDX-License-Identifier: Apache-2.0

--- a/scripts/sphinx_extensions/bridle/link-roles.py
+++ b/scripts/sphinx_extensions/bridle/link-roles.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # Copyright (c) 2019 Intel Corporation
 #

--- a/scripts/sphinx_extensions/options_from_kconfig/__init__.py
+++ b/scripts/sphinx_extensions/options_from_kconfig/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/sphinx_extensions/options_from_kconfig/options_from_kconfig.py
+++ b/scripts/sphinx_extensions/options_from_kconfig/options_from_kconfig.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/services/Kconfig
+++ b/services/Kconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/soc/arm/stm32f767xx/Kconfig
+++ b/soc/arm/stm32f767xx/Kconfig
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
+
 if SOC_FAMILY_STM32
 
 choice

--- a/soc/arm/stm32f767xx/Kconfig.defconfig
+++ b/soc/arm/stm32f767xx/Kconfig.defconfig
@@ -1,5 +1,7 @@
 # ST Microelectronics STM32F7 MCU line
 
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2021 Li-Pro.Net
 # Copyright (c) 2018 Yurii Hamann
 # SPDX-License-Identifier: Apache-2.0
 

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -1,3 +1,4 @@
+# Copyright (c) 2021 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 

--- a/west.yml
+++ b/west.yml
@@ -1,4 +1,8 @@
-# The west manifest file for Li-Pro.Net bridle to embedded environment.
+# The west manifest file for Bridle for embedded systems based on Zephyr.
+#
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2019-2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
 #
 # The per-installation west configuration file, .west/config, sets the
 # path to the project containing this file in the [manifest] section's

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2019-2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
+
 build:
   # root cmake script
   cmake: .


### PR DESCRIPTION
- fix cutted phrases in quick-link-matrix on HTML landing page in documentation
- fix project name in README
- add copyright string for TiaC Systems