### PR TITLE
doc: restore color scheme for Bridle docset

### DIFF
--- a/doc/_static/css/bridle.css
+++ b/doc/_static/css/bridle.css
@@ -1,5 +1,6 @@
 :root {
-  --docset-color: #00a9ce;
+  --docset-color: #15729d;
+  --visited-color: #154099;
 }
 
 /* Home page grid display */
@@ -82,7 +83,7 @@
 }
 
 .wy-nav-content a:visited {
-  color: #0077c8;
+  color: var(--visited-color);
 }
 
 /* Doc link boxes on the start page */

--- a/doc/_static/css/common.css
+++ b/doc/_static/css/common.css
@@ -2,7 +2,7 @@
 
 /* Bridle */
 .bridle {
-    background-color: #00a9ce;
+    background-color: #15729d;
 }
 
 /* Zephyr Project RTOS */


### PR DESCRIPTION
HOT FIX after release:

- adjust wrong background value (#00a9ce) to #15729d
- also adjust color for visited links (#0077c8) to #154099