### PR TITLE
Fixes and backports from v3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2021-2022 TiaC Systems
 # Copyright (c) 2019-2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
-# set to know where our project lies
-set(BRIDLE_DIR "${CMAKE_CURRENT_LIST_DIR}"
+# Set to know where our project lies.
+set(BRIDLE_BASE "${CMAKE_CURRENT_LIST_DIR}"
     CACHE PATH "Bridle root directory")
 
 include(cmake/version.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,22 +6,47 @@
 set(BRIDLE_BASE "${CMAKE_CURRENT_LIST_DIR}"
     CACHE PATH "Bridle root directory")
 
-include(cmake/version.cmake)
+# Generate our version header and inject into all builds.
+add_custom_command(
+  OUTPUT ${PROJECT_BINARY_DIR}/include/generated/version_bridle.h
+  COMMAND ${CMAKE_COMMAND}
+    -DZEPHYR_BASE=${ZEPHYR_BASE}
+    -DBRIDLE_BASE=${BRIDLE_BASE}
+    -DOUT_DIR=${PROJECT_BINARY_DIR}/include/generated
+    -DOUT_FILE=version_bridle.h
+    -DEXT_FILE=version.h
+    -P ${BRIDLE_BASE}/cmake/gen_version_h.cmake
+  DEPENDS ${BRIDLE_BASE}/VERSION ${git_dependency}
+)
+add_custom_target(version_bridle_h
+  DEPENDS ${PROJECT_BINARY_DIR}/include/generated/version_bridle.h)
+add_dependencies(zephyr_interface version_bridle_h)
+
+add_custom_target(version_h
+  DEPENDS ${PROJECT_BINARY_DIR}/include/generated/version.h)
+add_dependencies(version_bridle_h version_h)
 
 # include custom headers for e.g. drivers or services sorted by sub-folders
 zephyr_include_directories(include)
 
+# Unfortunately, the order in which CMakeLists.txt code is processed
+# matters so we need to be careful about how we order the processing
+# of subdirectories.
+#
+# Lib is placed early because it defines important common supports
+# that must be exported to other source partitions, e.g. subsys/.
+
+# add custom support libraries (e.g. algorithms)
+add_subdirectory(lib)
+
 # add custom services (e.g. control engines)
 add_subdirectory(services)
 
-# add custom sub-system modules (e.g. logging)
+# add custom sub-system modules (e.g. shell commands or logging)
 add_subdirectory(subsys)
 
 # add custom device drivers (e.g. sensor and actuator chips)
 add_subdirectory(drivers)
-
-# add custom support libraries (e.g. commands)
-add_subdirectory(lib)
 
 # add external 3rd party modules (e.g. MicroPython or LUA)
 add_subdirectory(modules)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,8 +21,15 @@
 /README.md                                @rexut
 /west.yml                                 @rexut
 
+# All cmake related files
+/CMakeLists.txt                           @rexut
+/cmake/                                   @rexut
+/share/*-package/                         @rexut
+
+# GH workfolws
 /.github/                                 @rexut
 /.github/workflows/                       @rexut
+
 /arch/                                    @rexut
 /soc/arm/                                 @rexut
 /soc/arm/stm32f767xx/                     @rexut
@@ -38,9 +45,6 @@
 /boards/sparc/                            @rexut
 /boards/x86/                              @rexut
 /boards/xtensa/                           @rexut
-# All cmake related files
-/cmake/                                   @rexut
-/CMakeLists.txt                           @rexut
 /doc/                                     @rexut
 /drivers/                                 @rexut
 /dts/arm/st/                              @rexut
@@ -59,5 +63,6 @@
 /subsys/shell/                            @rexut
 /subsys/shell/modules/                    @rexut
 /zephyr/                                  @rexut
+
 # Get all docs reviewed
 *.rst                                     @rexut

--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -1,0 +1,11 @@
+# Copyright (c) 2021-2022 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# This boilerplate is automatically included through ZephyrBuildConfig.cmake,
+# found in ${BRIDLE_BASE}/share/zephyrbuild-package/cmake/ as 
+# ZephyrBuildConfig.cmake. For more information regarding the Zephyr Build
+# Configuration CMake package, please refer to:
+#
+#   https://bridle.tiac-systems.net/doc/latest/zephyr/guides/zephyr_cmake_package.html#zephyr-build-configuration-cmake-package
+
+include(${BRIDLE_BASE}/cmake/version.cmake)

--- a/cmake/gen_version_h.cmake
+++ b/cmake/gen_version_h.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2021-2022 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+include(${BRIDLE_BASE}/cmake/version.cmake)
+configure_file(${BRIDLE_BASE}/version.h.in ${OUT_DIR}/${OUT_FILE})
+file(APPEND ${OUT_DIR}/${EXT_FILE} "\n#include \"${OUT_FILE}\"\n")

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2021-2022 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 #.rst:
@@ -8,7 +8,7 @@
 # Inputs:
 #
 #   ``*VERSION*`` and other constants set by
-#   maintainers in ``${BRIDLE_DIR}/VERSION``
+#   maintainers in ``${BRIDLE_BASE}/VERSION``
 #
 # Outputs with examples::
 #
@@ -26,7 +26,7 @@
 
 
 include(${ZEPHYR_BASE}/cmake/hex.cmake)
-file(READ ${BRIDLE_DIR}/VERSION ver)
+file(READ ${BRIDLE_BASE}/VERSION ver)
 
 string(REGEX MATCH "VERSION_MAJOR = ([0-9]*)" _ ${ver})
 set(PROJECT_VERSION_MAJOR ${CMAKE_MATCH_1})
@@ -60,7 +60,7 @@ endif()
 set(PROJECT_VERSION_STR ${PROJECT_VERSION}${PROJECT_VERSION_EXTRA_STR})
 
 if (NOT NO_PRINT_VERSION)
-  message(STATUS "Bridle version: ${PROJECT_VERSION_STR} (${BRIDLE_DIR})")
+  message(STATUS "Bridle version: ${PROJECT_VERSION_STR} (${BRIDLE_BASE})")
 endif()
 
 set(MAJOR ${PROJECT_VERSION_MAJOR}) # Temporary convenience variable
@@ -85,7 +85,7 @@ endif()
 
 set(BRIDLE_VERSION_CODE ${BRIDLE_VERSION_NUMBER_INT})
 
-configure_file(${BRIDLE_DIR}/version.h.in ${ZEPHYR_BINARY_DIR}/include/generated/version_bridle.h)
+configure_file(${BRIDLE_BASE}/version.h.in ${ZEPHYR_BINARY_DIR}/include/generated/version_bridle.h)
 file(APPEND ${ZEPHYR_BINARY_DIR}/include/generated/version.h
      "\n#include \"version_bridle.h\"\n")
 

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -85,10 +85,6 @@ endif()
 
 set(BRIDLE_VERSION_CODE ${BRIDLE_VERSION_NUMBER_INT})
 
-configure_file(${BRIDLE_BASE}/version.h.in ${ZEPHYR_BINARY_DIR}/include/generated/version_bridle.h)
-file(APPEND ${ZEPHYR_BINARY_DIR}/include/generated/version.h
-     "\n#include \"version_bridle.h\"\n")
-
 # Cleanup convenience variables
 unset(MAJOR)
 unset(MINOR)

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -2,6 +2,8 @@ docutils>=0.16
 pygments~=2.11
 recommonmark==0.7.1
 commonmark==0.9.1
+Jinja2>=2.3,<3.0
+MarkupSafe>=0.23,<2.1
 sphinx-tsn-theme~=2021.7
 sphinxcontrib-mscgen==0.6
 sphinxcontrib-svg2pdfconverter==1.1.1

--- a/share/tsn-package/cmake/TsnConfig.cmake
+++ b/share/tsn-package/cmake/TsnConfig.cmake
@@ -1,0 +1,14 @@
+# Copyright (c) 2021-2022 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# Relative directory of Bridle directoryy as seen from the
+# ZephyrExtension package file.
+set(BRIDLE_RELATIVE_DIR "../../..")
+
+# Set the current BRIDLE_BASE
+# The use of get_filename_component ensures that the final path variable will not contain `../..`.
+get_filename_component(BRIDLE_BASE ${CMAKE_CURRENT_LIST_DIR}/${BRIDLE_RELATIVE_DIR} ABSOLUTE)
+
+if(NOT NO_BOILERPLATE)
+  include(${BRIDLE_BASE}/cmake/boilerplate.cmake NO_POLICY_SCOPE)
+endif()

--- a/share/zephyrbuild-package/cmake/ZephyrBuildConfig.cmake
+++ b/share/zephyrbuild-package/cmake/ZephyrBuildConfig.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2021-2022 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# The ZephyrBuildConfig is simply including TSN package.
+include(${CMAKE_CURRENT_LIST_DIR}/../../tsn-package/cmake/TsnConfig.cmake)


### PR DESCRIPTION
- fix PyPi package interferences (Jinja2 and MarkupSafe reflected with Sphinx ~=3.3)
-  auto-load our new boilerplate by Zephyr
-  new "version_bridle.h" generator