### PR TITLE
ci: github-script: cope with V5 breaking changes

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{ github.event.workflow_run.id }},
@@ -28,7 +28,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "doc"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,


### PR DESCRIPTION
The actions/github-script was recently updated from v3.1.0 to v6 to catch Node 16 (f49acac1ef17b61f5945621ac99e4d7a3049a3a6), but unfortunately there were breaking changes in the API with v5:

* https://github.com/actions/github-script#breaking-changes-in-v5
* https://github.com/actions/github-script/issues/242 (comment)

Error was manifest as:

TypeError: Cannot read properties of undefined (reading 'listWorkflowRunArtifacts')
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:13355:16), <anonymous>:3:38)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:13356:12)
    at main (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:13451:26)
    at Module.858 (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:13428:1)
    at __webpack_require__ (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:24:31)
    at startup (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:43:19)
    at /home/runner/work/_actions/actions/github-script/v6/dist/index.js:49:18
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:52:10)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)

So update our code to to use the new way to do things.

issues: #62

Signed-off-by: Stephan Linz <linz@li-pro.net>