### PR TITLE
Add devcontainer integration for vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,50 @@
+ARG ZEPHYR_TAG=latest
+FROM zephyrprojectrtos/ci:${ZEPHYR_TAG}
+
+# Set default to bash instead sh
+ENV SHELL /bin/bash
+
+RUN add-apt-repository ppa:tiac-systems/doxygen
+
+# Install packages
+RUN apt-get -y update && \
+	apt-get -y upgrade && \
+	apt-get install --no-install-recommends -y \
+	doxygen \
+	graphviz \
+	mscgen \
+	latexmk \
+	librsvg2-bin \
+	texlive-latex-base \
+	texlive-latex-extra \
+	texlive-fonts-recommended \
+	usbutils \
+	vim
+
+# Clean up stale packages
+RUN apt-get clean -y && \
+	apt-get autoremove --purge -y && \
+	rm -rf /var/lib/apt/lists/*
+
+# Add bash completion script
+ADD ./bash_completion /home/user/.bash_completion
+RUN mkdir -p /home/user/.bash_completion.d
+
+# Switch to 'user' context
+USER user
+
+RUN mkdir -p /home/user/.vscode-server/extensions
+
+# Set working directory
+WORKDIR /workdir
+VOLUME ["/workdir"]
+
+# Adjust 'user' home directory permissions
+USER root
+RUN chown -R user:user /home/user
+
+# Make 'user' default on launch
+USER user
+
+# Launch bash shell by default
+CMD ["/bin/bash"]

--- a/.devcontainer/bash_completion
+++ b/.devcontainer/bash_completion
@@ -1,0 +1,3 @@
+for bcfile in ~/.bash_completion.d/* ; do
+	. $bcfile
+done

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+
+{
+	"name": "Bridle",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Specify version for Zephyr Container
+		// See https://github.com/zephyrproject-rtos/docker-image/releases
+		"args": { "ZEPHYR_TAG": "v0.26.4" }
+	},
+	// Needed for USB devices in container
+	"privileged": true,
+	"postCreateCommand": "bash .devcontainer/post-create.sh /workspace ${localWorkspaceFolderBasename}",
+	"postStartCommand": "bash .devcontainer/post-start.sh /workspace",
+	// Mount and set workspace folder
+	"workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspace,type=bind",
+    "workspaceFolder": "/workspace/${localWorkspaceFolderBasename}",
+	// Username in container - align with Dockerfil
+    "remoteUser": "user",
+	"mounts": [
+		// Persist installed extensions in container
+		"source=bridle-devcontainer-extensions,target=/home/user/.vscode-server/extensions,type=volume",
+		// Allow attaching USB devices to running container
+		"source=/dev/bus/usb,target=/dev/bus/usb,type=bind"
+	],"customizations": {
+		"vscode": {
+			"settings": {
+				"editor.trimAutoWhitespace": true,
+				"editor.insertFinalNewline": true
+			},
+			"extensions": [
+				"marus25.cortex-debug"
+			]
+		}
+	}
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+WORKSPACE_DIR=$1
+REPO_NAME=$2
+
+cd $WORKSPACE_DIR
+
+if [ ! -d ".west" ]; then
+    west init -l $REPO_NAME
+fi
+
+west update
+west bridle-export
+
+
+pip3 install --upgrade --requirement zephyr/scripts/requirements.txt
+pip3 install --upgrade --requirement bridle/scripts/requirements.txt

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+WORKSPACE_DIR=$1
+
+cd $WORKSPACE_DIR
+
+west update

--- a/.github/qa-igt-slz/map-nucleo_g071rb.yml
+++ b/.github/qa-igt-slz/map-nucleo_g071rb.yml
@@ -1,0 +1,7 @@
+- available: true
+  connected: true
+  id: 066BFF484951717867061436
+  platform: nucleo_g071rb
+  product: STM32 STLink
+  runner: openocd
+  serial: /dev/ttyACM0

--- a/.github/workflows/qa-igt-slz.yml
+++ b/.github/workflows/qa-igt-slz.yml
@@ -1,0 +1,101 @@
+# Copyright (c) 2021-2022 TiaC Systems
+# Copyright (c) 2021 Li-Pro.Net
+# SPDX-License-Identifier: Apache-2.0
+
+name: QA Integration Test (Hackfest 2022 / SLZ)
+
+on:
+  workflow_dispatch: # And manually on button click
+
+jobs:
+  qa-integration:
+    name: Run integration tests on targets
+    runs-on: [self-hosted, linux, gnuarmemb, zephyr-sdk, nucleo_g071rb]
+
+    strategy:
+      matrix:
+        board: [nucleo_g071rb]
+
+    steps:
+      - name: Update GitHub PATH for west
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Clean working directory
+        run: |
+          rm -rf "${{ github.workspace }}/workspace"
+
+      - name: Checkout the code
+        uses: actions/checkout@v3
+        with:
+          path: workspace/bridle
+          submodules: recursive
+          ref: ${{ github.ref }}
+
+      - name: Install base dependencies
+        working-directory: workspace
+        run: |
+          pip3 install --upgrade pip
+          pip3 install --upgrade setuptools
+          pip3 install --upgrade --requirement bridle/scripts/requirements-base.txt
+
+      - name: West init and update
+        working-directory: workspace
+        run: |
+          west init -l bridle
+          west update
+          west zephyr-export
+          west bridle-export
+
+      - name: Install build and test dependencies
+        working-directory: workspace
+        run: |
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-base.txt
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-build-test.txt
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-run-test.txt
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-extras.txt
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-compliance.txt
+          pip3 install --upgrade --requirement bridle/scripts/requirements-build.txt
+
+      - name: Execute integration tests on target
+        working-directory: workspace
+        env:
+          HARDWARE_MAP: bridle/.github/${{ github.job }}/map-${{ matrix.board }}.yml
+        run: |
+          #
+          # Disabled in the meantime because the execution time is still
+          # too high and most of the core tests are already performed by
+          # Zephyr in any case:
+          #
+          # --testsuite-root zephyr/tests/kernel \
+          # --testsuite-root zephyr/tests/arch/arm \
+          #
+          # Disabled in the meantime because the execution results
+          # <failure type="failure" message="Unknown" /> in the
+          # twister report XML file:
+          #
+          # --testsuite-root bridle/tests/drivers/watchdog \
+          #
+          export ZEPHYR_BASE="$(pwd)/zephyr"
+          export BRIDLE_BASE="$(pwd)/bridle"
+          ./zephyr/scripts/twister --verbose --jobs 1 --inline-logs \
+            --enable-size-report --platform-reports \
+            --device-testing --hardware-map ${HARDWARE_MAP} \
+            --testsuite-root zephyr/tests/kernel/mutex/sys_mutex
+        continue-on-error: true
+
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: twister_report.xml
+          path: workspace/twister-out/twister_report.xml
+        continue-on-error: true
+
+      - name: Convert integration test reports to annotations
+        uses: mikepenz/action-junit-report@v3
+        with:
+          check_name: twister-report (${{ matrix.board }})
+          report_paths: "**/twister-out/twister_report.xml"
+          require_tests: true
+          fail_on_failure: false
+        if: always()

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -71,3 +71,6 @@
 
 # Get all docs reviewed
 *.rst                                     @rexut
+
+# Devcontainer setup for vscode
+/.devcontainer/                           @rexut


### PR DESCRIPTION
This will auto setup the whole build environment based on zephyr's docker containers. Prerequisites are:
- docker is accessable by the user without using sudo
- vscode with remote container extension is installed

Create a directory for your workspace. Go into that directory and clone the bridle repo.
Open the repo folder in vscode and select from the commands "Dev Containers: Reopen in container" (you might be prompted in the bottom right corner for that).

This will then download the docker container, install packages etc. so that you can directly start with a `west build` 