### PR TITLE
Add a fancier button/led example

### DIFF
--- a/samples/button/CMakeLists.txt
+++ b/samples/button/CMakeLists.txt
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(very-simple-app)
+
+
+target_sources_ifdef(
+			CONFIG_APPLICATION_MODE_POLLING
+			app PRIVATE
+            src/poll.c
+)
+
+target_sources_ifdef(
+			CONFIG_APPLICATION_MODE_INTERRUPT
+			app PRIVATE
+            src/event.c
+)
+
+target_sources(
+	app PRIVATE
+	src/init.c
+)

--- a/samples/button/Kconfig
+++ b/samples/button/Kconfig
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+mainmenu "Button"
+
+choice APPLICATION_MODE
+	prompt "Application Mode"
+
+config APPLICATION_MODE_POLLING
+    bool "Poll button state"
+
+config APPLICATION_MODE_INTERRUPT
+	bool "Use an interrupt and callback"
+
+endchoice
+
+if APPLICATION_MODE_POLLING
+
+config SLEEP_TIME_MS
+    int "Polling loop sleep time"
+    default 1
+    help
+        This defines how long the polling loop waits
+        between subsequent queries of the push button
+        state
+        
+endif
+
+# Sources Kconfig.zephyr in the Zephyr root directory.
+source "Kconfig.zephyr"

--- a/samples/button/README.rst
+++ b/samples/button/README.rst
@@ -1,0 +1,119 @@
+.. _button-sample:
+
+Button
+######
+
+Overview
+********
+
+A simple button demo showcasing the use of GPIO input using a dedicated polling
+thread, spawned by an init function. Alternatively, it can be configured to use
+interrupts instead.
+In either mode, pressing the button will light up an led.
+
+Requirements
+************
+
+The board hardware must have a push button connected via a GPIO pin. These are
+called "User buttons" on many of Zephyr's :ref:`boards`.
+
+The button must be configured using the ``sw0`` :ref:`devicetree <dt-guide>`
+alias, usually in the :ref:`BOARD.dts file <devicetree-in-out-files>`. You will
+see this error if you try to build this sample for an unsupported board:
+
+.. code-block:: none
+
+   Unsupported board: sw0 devicetree alias is not defined
+
+You may see additional build errors if the ``sw0`` alias exists, but is not
+properly defined.
+
+Additionally, the sample requires the ``led0`` devicetree alias.
+
+Devicetree details
+==================
+
+This section provides more details on devicetree configuration.
+
+Here is a minimal devicetree fragment which supports this sample, containing
+both an ``sw0`` and an ``led0`` alias.
+
+.. code-block:: devicetree
+
+   / {
+   	aliases {
+   		sw0 = &button0;
+   		led0 = &green_led_1;
+   	};
+
+   	soc {
+   		gpio0: gpio@0 {
+   			status = "okay";
+   			gpio-controller;
+   			#gpio-cells = <2>;
+   			/* ... */
+   		};
+   	};
+
+   	buttons {
+   		compatible = "gpio-keys";
+   		button0: button_0 {
+   			gpios = < &gpio0 PIN FLAGS >;
+   			label = "User button";
+   		};
+   		/* ... other buttons ... */
+   	};
+
+   	leds {
+		compatible = "gpio-leds";
+	 	green_led_1: led_1 {
+	 		gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
+	 		label = "User LD1";
+	 	};
+   		/* ... other leds ... */
+	 	
+   };
+
+As shown, the ``sw0`` devicetree alias must point to a child node of a node
+with a "gpio-keys" :ref:`compatible <dt-important-props>`, and the ``led0``
+alias must point to a child node of one with a "gpio-leds" :ref:`compatible <dt-important-props>`.
+
+The above situation is for the common case where:
+
+- ``gpio0`` is an example node label referring to a GPIO controller
+-  ``PIN`` should be a pin number, like ``8`` or ``0``
+- ``FLAGS`` should be a logical OR of :ref:`GPIO configuration flags <gpio_api>`
+  meant to apply to the button, such as ``(GPIO_PULL_UP | GPIO_ACTIVE_LOW)``
+
+This assumes the common case, where ``#gpio-cells = <2>`` in the ``gpio0``
+node, and that the GPIO controller's devicetree binding names those two cells
+"pin" and "flags" like so:
+
+.. code-block:: yaml
+
+   gpio-cells:
+     - pin
+     - flags
+
+This sample requires a ``pin`` cell in the ``gpios`` property. The ``flags``
+cell is optional, however, and the sample still works if the GPIO cells
+do not contain ``flags``.
+
+Building and Running
+********************
+
+This sample can be built for multiple boards, in this example we will build it
+for the nucleo_f413zh board:
+
+.. zephyr-app-commands::
+   :zephyr-app: bridle/samples/button
+   :board: nucleo_f413zh
+   :goals: build
+   :compact:
+
+During startup, an init function look up predefined GPIO devices, and
+configures their pins in input and output mode, respectively. Depending on
+the build configuration, an additional init function either spawns a
+dedicated polling thread which continuously monitors the button state and
+adjusts the led state to match, or sets up an interrupt that does the same
+whenever the button is pressed or released.

--- a/samples/button/prj.conf
+++ b/samples/button/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_GPIO=y

--- a/samples/button/src/event.c
+++ b/samples/button/src/event.c
@@ -1,0 +1,36 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+*/
+#include <zephyr/device.h>
+#include "init.h"
+
+/* Interrupt handler  */
+static void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	// Only trigger on the correct pin
+	if (pins & BIT(btn.pin))
+	{
+		int val = gpio_pin_get(dev, btn.pin);
+		gpio_pin_set_dt(&led, val);
+	}
+}
+
+
+/* Init function which creates the interrupt callback  */
+static int init()
+{
+	// Configure btn to trigger interrupts on both press and release
+	gpio_pin_interrupt_configure_dt(&btn, GPIO_INT_EDGE_BOTH);
+
+	// Create and fill the callback struct
+	static struct gpio_callback button_cb_data;
+	gpio_init_callback(&button_cb_data, button_pressed, BIT(btn.pin));
+
+	// Register the callback
+	gpio_add_callback(btn.port, &button_cb_data);
+
+	return 0;
+}
+
+/* Register our init function */
+SYS_INIT(init, APPLICATION, APPLICATION_CB_INIT_PRIORITY);

--- a/samples/button/src/init.c
+++ b/samples/button/src/init.c
@@ -1,0 +1,36 @@
+#include "init.h"
+
+/* Setup for a button  */
+#define BTN_NODE DT_ALIAS(sw0)
+#if !DT_NODE_HAS_STATUS(BTN_NODE, okay)
+#error "Unsupported board: sw0 devicetree alias is not defined"
+#endif
+
+const struct gpio_dt_spec btn = GPIO_DT_SPEC_GET(BTN_NODE, gpios);
+
+
+/* Setup for an led */
+#define LED_NODE DT_ALIAS(led0)
+#if !DT_NODE_HAS_STATUS(LED_NODE, okay)
+#error "Unsupported board: led0 devicetree alias is not defined"
+#endif
+
+const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED_NODE, gpios);
+
+/* Init function for configuring button and led gpio pins */
+static int init()
+{
+	gpio_pin_configure_dt(&btn, GPIO_INPUT);
+	gpio_pin_configure_dt(&led, GPIO_OUTPUT);
+
+	return 0;
+}
+
+/* Register our init function  */
+SYS_INIT(init, APPLICATION, APPLICATION_IO_INIT_PRIORITY);
+
+/* Empty main */
+void main(void)
+{	
+
+}

--- a/samples/button/src/init.h
+++ b/samples/button/src/init.h
@@ -1,0 +1,9 @@
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+
+extern const struct gpio_dt_spec btn;
+extern const struct gpio_dt_spec led;
+extern const struct gpio_dt_spec led2;
+
+#define APPLICATION_IO_INIT_PRIORITY 96
+#define APPLICATION_CB_INIT_PRIORITY 97

--- a/samples/button/src/poll.c
+++ b/samples/button/src/poll.c
@@ -1,0 +1,47 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+*/
+#include <zephyr/device.h>
+#include "init.h"
+
+/* Setup for creating the polling thread */
+#define MY_STACK_SIZE 512
+#define MY_PRIORITY 5
+
+K_THREAD_STACK_DEFINE(polling_thread_stack_area, MY_STACK_SIZE);
+
+/* Entry point function for the polling thread  */
+static void polling_thread_entry_point(void *btn_void, void *led_void, void *)
+{
+	// Unwrap the argument pointers
+	struct gpio_dt_spec *btn = (struct gpio_dt_spec*) btn_void;
+	struct gpio_dt_spec *led = (struct gpio_dt_spec*) led_void;
+
+	// Infinite polling loop
+	while (1)
+	{
+		int val = gpio_pin_get_dt(btn);
+		gpio_pin_set_dt(led, val);
+
+		// Sleep the thread for a little while
+		k_msleep(CONFIG_SLEEP_TIME_MS);
+	}	
+}
+
+/* Init function which spawns a dedicated polling thread  */
+static int init()
+{
+	struct k_thread polling_thread;
+
+	__unused k_tid_t tid = k_thread_create(&polling_thread,
+									polling_thread_stack_area,
+	                                K_THREAD_STACK_SIZEOF(polling_thread_stack_area),
+	                                polling_thread_entry_point,
+	                                (void*) &btn, (void*) &led, NULL,
+	                                MY_PRIORITY, 0, K_NO_WAIT);
+	                                 
+	return 0;
+}
+
+/* Register our init function */
+SYS_INIT(init, APPLICATION, APPLICATION_CB_INIT_PRIORITY);


### PR DESCRIPTION
See #99. This adds an example application that showcases
- Using a dedicated polling thread
- Setting up GPIO interrupts
- Using the Zephyr init system to perform initialization
- Using Kconfig options to switch between modes of operation at compile time