### PR TITLE
Fix C and C++ standard violation

### DIFF
--- a/doc/bridle/releases/release-notes-3.5.0.rst
+++ b/doc/bridle/releases/release-notes-3.5.0.rst
@@ -104,7 +104,7 @@ Change log
 
 :brd:`NOT YET, tbd.`
 
-* tbd.
+* Switch main return type from void to int for all samples.
 * tbd.
 * tbd.
 
@@ -138,6 +138,7 @@ Issue Related Items
 
 These GitHub issues were addressed since project bootstrapping:
 
+* :github:`120` - [BUG] Nightly QA integration test fails
 * :github:`118` - [BUG] QA Integration Test fails
 * :github:`116` - [BUG] Grove Shields DTS Binding test suites fail for seeeduino_lotus@usbcons
 * :github:`115` - [BUG] Bridle Common (core) Testing fails since v3.4

--- a/samples/button/src/init.c
+++ b/samples/button/src/init.c
@@ -34,4 +34,4 @@ static int init()
 SYS_INIT(init, APPLICATION, APPLICATION_IO_INIT_PRIORITY);
 
 /* Empty main */
-void main(void) {}
+int main(void) {return 0;}

--- a/samples/helloshell/src/main.c
+++ b/samples/helloshell/src/main.c
@@ -8,7 +8,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello World! I'm THE SHELL from %s\n", CONFIG_BOARD);
+	return 0;
 }


### PR DESCRIPTION
As both C and C++ standards require applications running under an OS to return 'int', adapt that for Bridle to align with those standard.

Related to issue #120.