### PR TITLE
samples: helloshell: avoid FLASH overflow on qemu_nios2

### DIFF
--- a/samples/helloshell/boards/qemu_nios2.conf
+++ b/samples/helloshell/boards/qemu_nios2.conf
@@ -4,3 +4,8 @@
 # disable unsupported components or components with issues
 CONFIG_FLASH=n
 CONFIG_FLASH_SHELL=n
+
+# disable components to avoid FLASH overflow on RODATA allocation
+CONFIG_SENSOR=n
+CONFIG_SENSOR_INFO=n
+CONFIG_SENSOR_SHELL=n


### PR DESCRIPTION
Disable SENSORS components to avoid FLASH overflow on RODATA allocation.