### PR TITLE
tests: can: use snippet 'can-timing-adj'

### DIFF
--- a/.github/workflows/qa-integration.yml
+++ b/.github/workflows/qa-integration.yml
@@ -36,6 +36,90 @@ on:
       - '.github/workflows/qa-integration.yml'
 
 jobs:
+  qa-samples-integration:
+    name: Run integration tests for samples
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci:v0.26.4
+      options: '--entrypoint /bin/bash'
+    env:
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.1
+
+    steps:
+      - name: Apply container owner mismatch workaround
+        run: |
+          # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not
+          #        match the container user UID because of the way GitHub
+          #        Actions runner is implemented. Remove this workaround when
+          #        GitHub comes up with a fundamental fix for this problem.
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Update GitHub PATH for west
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Checkout the code
+        uses: actions/checkout@v3
+        with:
+          path: workspace/bridle
+          submodules: recursive
+          ref: ${{ github.ref }}
+
+      - name: Restore PIP Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-qa-pip
+
+      - name: Install base dependencies
+        working-directory: workspace
+        run: |
+          pip3 install --upgrade pip
+          pip3 install --upgrade setuptools
+          pip3 install --upgrade --requirement bridle/scripts/requirements-base.txt
+
+      - name: West init and update
+        working-directory: workspace
+        run: |
+          west init -l bridle
+          west update
+          west zephyr-export
+          west bridle-export
+
+      - name: Install build and test dependencies
+        working-directory: workspace
+        run: |
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-base.txt
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-build-test.txt
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-run-test.txt
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-extras.txt
+          pip3 install --upgrade --requirement zephyr/scripts/requirements-compliance.txt
+          pip3 install --upgrade --requirement bridle/scripts/requirements-build.txt
+
+      - name: Build samples
+        working-directory: workspace
+        run: |
+          west twister --verbose --jobs 4 --integration \
+            --outdir twister-out --no-clean --inline-logs \
+            --enable-size-report --platform-reports \
+            --testsuite-root bridle/samples/button \
+            --testsuite-root bridle/samples/helloshell
+
+      - name: Upload integration test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: twister-samples.xml
+          path: workspace/twister-out/twister.xml
+
+      - name: Convert integration test reports to annotations
+        uses: mikepenz/action-junit-report@v3
+        with:
+          check_name: twister-report (shields)
+          report_paths: "**/twister-out/twister.xml"
+          require_tests: true
+          fail_on_failure: false
+        if: always()
+
   qa-shield-integration:
     name: Run integration tests for shields
     runs-on: ubuntu-latest
@@ -125,15 +209,6 @@ jobs:
             --platform waveshare_rp2040_plus@16mb \
             --testsuite-root bridle/tests/shields/grove/dts_bindings \
             --testsuite-root bridle/tests/shields/x_grove_testbed/dts_bindings
-
-      - name: Build samples
-        working-directory: workspace
-        run: |
-          west twister --verbose --jobs 4 --integration \
-            --outdir twister-out --no-clean --inline-logs \
-            --enable-size-report --platform-reports \
-            --testsuite-root bridle/samples/button \
-            --testsuite-root bridle/samples/helloshell
 
       - name: Upload integration test results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
With this alternative configuration the downstream project will be able to preset the Zephyr upstream CAN test suite with different overlays and configurations for specific boards, started with 'tiac_magpie'.

The following Zephyr upstream PRs will be needed:

- https://github.com/zephyrproject-rtos/zephyr/pull/63232
- https://github.com/zephyrproject-rtos/zephyr/pull/63372