### PR TITLE
feat: upgrade CMake

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,6 +21,11 @@ RUN apt-get -y update && \
 	usbutils \
 	vim
 
+# Use newer cmake for debugging option
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+	echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+	apt-get update && apt install --no-install-recommends -y cmake
+
 # Clean up stale packages
 RUN apt-get clean -y && \
 	apt-get autoremove --purge -y && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
 				"editor.insertFinalNewline": true
 			},
 			"extensions": [
-				"marus25.cortex-debug"
+				"marus25.cortex-debug",
+				"ms-vscode.cmake-tools"
 			]
 		}
 	}


### PR DESCRIPTION
To interactively debug CMake version 3.27 is required. As this container is based on the Zephyr SDK which is based on an Ubuntu LTS version, CMake is too old to support debugging.

Therefore we install CMake from their repository and add the CMake extension to the devcontainer file for auto-install it.