### PR TITLE
Adapt QA integration tests for time and disk space consumption

### DIFF
--- a/samples/helloshell/sample.yaml
+++ b/samples/helloshell/sample.yaml
@@ -17,8 +17,8 @@ common:
     - qemu_cortex_a9
     - qemu_cortex_a53
     - qemu_kvm_arm64
-    - qemu_arc_em
-    - qemu_arc_hs
+    # - qemu_arc_em
+    # - qemu_arc_hs
     - qemu_malta
     - qemu_malta_be
     - qemu_riscv32e

--- a/zephyr/alt-config/drivers/can/shell/testcase.yaml
+++ b/zephyr/alt-config/drivers/can/shell/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  timeout: 120
+  timeout: 600
 tests:
   drivers.can.shell:
     integration_platforms:


### PR DESCRIPTION
- wait longer on real hardware in our RPi4 test bed environment for CAN test suite (shell API)
- disable QEMU/ARC platforms, because of huge disk space consumption (about 2.2GB)