### PR TITLE
doc: doxygen: respect macro for nonnull attribute

### DIFF
--- a/doc/_doxygen/doxyfile-bridle.in
+++ b/doc/_doxygen/doxyfile-bridle.in
@@ -2452,6 +2452,7 @@ PREDEFINED             = __DOXYGEN__ \
                          __deprecated= \
                          __packed= \
                          __aligned(x)= \
+                         __attribute_nonnull(...)= \
                          "__printf_like(x, y)=" \
                          __attribute__(x)= \
                          __syscall= \

--- a/doc/_doxygen/doxyfile-zephyr.in
+++ b/doc/_doxygen/doxyfile-zephyr.in
@@ -2455,6 +2455,7 @@ PREDEFINED             = __DOXYGEN__ \
                          __deprecated= \
                          __packed= \
                          __aligned(x)= \
+                         __attribute_nonnull(...)= \
                          "__printf_like(x, y)=" \
                          __attribute__(x)= \
                          __syscall= \


### PR DESCRIPTION
Zephyr upstream now uses a new (private) CPP macro to handle nonnull attribute in internal kernel API. Thus Doxygen have to know about and strip the declarations.