### PR TITLE
Create a nix flake for reproducible development and build environments

### DIFF
--- a/doc.nix
+++ b/doc.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, west2nixHook
+, pythonEnv
+, cmake
+, ninja
+, doxygen
+, mscgen
+, graphviz
+, git
+, zephyr
+, bridle
+}:
+
+stdenv.mkDerivation {
+
+  name = "bridle-doc";
+  src = bridle;
+  unpackPhase = ''
+    cp -r ${bridle} bridle
+    chmod +w -R bridle
+    cd bridle
+    git init
+    git config user.email "foo@bar.com"
+    git config user.name "Foo"
+    git checkout -b fake-branch
+    git add -A
+    git commit -m "Fake Commnit"
+    cd ..
+  '';
+
+  nativeBuildInputs = [
+    west2nixHook
+    pythonEnv
+    cmake
+    ninja
+    doxygen
+    mscgen
+    graphviz
+    git
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  CMAKE_PREFIX_PATH = "/build/bridle/share/bridle-package:/build/zephyr/share/zephyr-package";
+
+  buildPhase = ''
+    cd /build
+    chmod +w -R ./*
+    west build --cmake-only -b none -d build bridle/doc
+    west build -t zephyr-doxygen -b none -d build
+    west build -t bridle-doxygen -b none -d build
+    west build -t build-all -b none -d build
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp -r build/html $out/
+  '';
+}

--- a/doc/bridle/getting_started.rst
+++ b/doc/bridle/getting_started.rst
@@ -3,10 +3,10 @@
 Getting started
 ###############
 
-To quickly get started with |BRIDLE|, use the
-:ref:`Getting Started Assistant <gs_assistant>` to set up your development
-environment. Alternatively, check the :ref:`gs_installing` section for
-instructions on setting up your environment manually.
+To quickly get started with |BRIDLE|, use the :ref:`Getting Started Assistant
+<gs_assistant>` to set up your development environment. Alternatively, check the
+:ref:`gs_installing` section for instructions on setting up your environment
+manually. To set up your system for using Bridle with Nix, see :ref:`gs_nix`.
 
 We recommend using [t.b.d.] for building your applications. See
 :ref:`gs_programming` for the download links and instructions. In case you
@@ -25,7 +25,7 @@ start developing!
    gs_recommended_versions
    gs_assistant
    gs_installing
+   gs_nix
    gs_programming
    gs_testing
    gs_modifying
-

--- a/doc/bridle/gs_nix.rst
+++ b/doc/bridle/gs_nix.rst
@@ -7,10 +7,10 @@ Working with Bridle via Nix
    :local:
    :depth: 2
 
-An alternative way to develop with Bridle is through `Nix <https://nixos.org/>`_, a functional package
-managing system. This way, all dependencies can be installed using a single
-tool. Packages installed this way don't pollute your regular system, and can
-easily be removed later.
+An alternative way to develop with Bridle is through `Nix
+<https://nixos.org/>`_, a functional package managing system. This way, all
+dependencies can be installed using a single tool. Packages installed this way
+don't pollute your regular system, and can easily be removed later.
 
 Installing the Nix Package Manager
 **********************************
@@ -18,41 +18,80 @@ Installing the Nix Package Manager
 To get started using Nix, you will need to install the package manager itself.
 Most distributions provide packages for installing it using their regular
 package manager (e.g. Ubuntu provides a ``nix`` package that can be installed
-using ``apt install nix``). If your distribution doesn't provide such a package, see the
-instructions on `nixos.org <https://nixos.org/download>` to get a Nix
+using ``apt install nix``). If your distribution doesn't provide such a package,
+see the instructions on `nixos.org <https://nixos.org/download>`_ to get a Nix
 installation.
 
 Enabling Flakes
 ***************
 
 Flakes are an experimental feature that enables fully hermetic and reproducible
-builds. To enable flakes, add
-
-.. parsed-literal::
-   :class: highlight
+builds. To enable flakes, add::
 
    experimental-features = nix-command flakes
 
-to ``~/.config/nix/nix.conf`` (creating this file if it doesn't exist).
+to your private Nix configuration in ``~/.config/nix/nix.conf`` (creating this
+file if it doesn't exist).
 
 Using the Bridle Flake
 **********************
 
 The Bridle flake provides a ``devShell`` output, which is a shell environment in
 which all necessary tools and dependencies are present for developing Zephyr
-applications with Bridle. By running `nix develop` within the bridle repository,
+applications with Bridle. By running ``nix develop`` within the bridle repository,
 you enter this environment. You can then proceed to create a west workspace
 ontop of your bridle directory and work as usual.
+
+You can also use the build hooks provided by the ``west2nix`` input to perform
+builds directly via Nix, without creating an explicit west workspace. In this
+case, the workspace manifest used will be that provided by the ``west2nix.toml``
+lockfile (see below on how to bring it up-to-date if required). For an example
+of such a derivation, see ``doc.nix``, which builds this documentation. For
+another example of a simpler build, see `the west2nix repository
+<https://github.com/adisbladis/west2nix>`_.
 
 Keeping the Bridle Flake Up-to-date
 ***********************************
 
 Like all nix flakes, the Bridle flake has its inputs locked using the
 ``flake.lock`` file. Running ``nix flake update`` in the bridle directory will
-check for upstream changes and bump any changed inputs in the lockfile.
+check for upstream changes and bump any changed inputs in the lockfile. After
+checking for breakages due to the update, e.g. via ``nix flake check``, and
+confirming that ``nix develop`` drops you into a working shell, you should can
+commit the updated ``flake.lock``. If you do notice breakage, you can simply
+revert the update with ``git checkout flake.lock``.
 
 The flake also relies on the manifest lockfile ``west2nix.toml``, which reflects
-the state of a west workspace at a specific time. To update this lockfile, the
-workspace you want to lock needs to be fully checked out. Within this workspace,
-run ``nix run bridle#west2nix`` to generate a new ``west2nix.toml``, which can
-then be placed in the bridle directory.
+the state of a west workspace at a specific time. To update this lockfile, you
+first need a full checkout of the workspace you want to lock:
+
+.. code-block:: console
+
+   mkdir workspace && cd workspace
+   git clone https://github.com/tiacsys/bridle.git
+   west init -l bridle
+   west update
+
+You can then run ``west2nix`` on this workspace and place the resulting lockfile
+into the ``bridle`` directory:
+
+.. code-block:: console
+
+   nix run ./bridle#west2nix
+   mv west2nix.toml bridle/
+
+.. note::
+
+   Running ``west2nix`` directly inside the ``bridle`` directory is
+   likely to fail due to permission issues, hence running it from the workspace
+   directory instead.
+
+Finally, you can commit your new lockfile:
+
+.. code-block:: console
+
+   git add west2nix.toml
+   git commit -m "Updated west2nix.toml"
+
+Similarly to updating the flake inputs, this update can be reverted simply by
+resetting ``west2nix.toml`` to an earlier state.

--- a/doc/bridle/gs_nix.rst
+++ b/doc/bridle/gs_nix.rst
@@ -1,0 +1,58 @@
+.. _gs_nix:
+
+Working with Bridle via Nix
+###########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+An alternative way to develop with Bridle is through `Nix <https://nixos.org/>`_, a functional package
+managing system. This way, all dependencies can be installed using a single
+tool. Packages installed this way don't pollute your regular system, and can
+easily be removed later.
+
+Installing the Nix Package Manager
+**********************************
+
+To get started using Nix, you will need to install the package manager itself.
+Most distributions provide packages for installing it using their regular
+package manager (e.g. Ubuntu provides a ``nix`` package that can be installed
+using ``apt install nix``). If your distribution doesn't provide such a package, see the
+instructions on `nixos.org <https://nixos.org/download>` to get a Nix
+installation.
+
+Enabling Flakes
+***************
+
+Flakes are an experimental feature that enables fully hermetic and reproducible
+builds. To enable flakes, add
+
+.. parsed-literal::
+   :class: highlight
+
+   experimental-features = nix-command flakes
+
+to ``~/.config/nix/nix.conf`` (creating this file if it doesn't exist).
+
+Using the Bridle Flake
+**********************
+
+The Bridle flake provides a ``devShell`` output, which is a shell environment in
+which all necessary tools and dependencies are present for developing Zephyr
+applications with Bridle. By running `nix develop` within the bridle repository,
+you enter this environment. You can then proceed to create a west workspace
+ontop of your bridle directory and work as usual.
+
+Keeping the Bridle Flake Up-to-date
+***********************************
+
+Like all nix flakes, the Bridle flake has its inputs locked using the
+``flake.lock`` file. Running ``nix flake update`` in the bridle directory will
+check for upstream changes and bump any changed inputs in the lockfile.
+
+The flake also relies on the manifest lockfile ``west2nix.toml``, which reflects
+the state of a west workspace at a specific time. To update this lockfile, the
+workspace you want to lock needs to be fully checked out. Within this workspace,
+run ``nix run bridle#west2nix`` to generate a new ``west2nix.toml``, which can
+then be placed in the bridle directory.

--- a/flake.lock
+++ b/flake.lock
@@ -3,27 +3,6 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
-          "pyproject-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1701473968,
-        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
           "zephyr-nix",
           "pyproject-nix",
           "nixpkgs"
@@ -40,21 +19,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1692742795,
-        "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "d9a70d9c7a5fd7f3258ccf48da9335e9b47c3937",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
         "type": "github"
       }
     },
@@ -94,10 +58,6 @@
     },
     "mdbook-nixdoc": {
       "inputs": {
-        "flake-parts": [
-          "pyproject-nix",
-          "flake-parts"
-        ],
         "nix-github-actions": [
           "pyproject-nix",
           "nix-github-actions"
@@ -105,18 +65,14 @@
         "nixpkgs": [
           "pyproject-nix",
           "nixpkgs"
-        ],
-        "treefmt-nix": [
-          "pyproject-nix",
-          "treefmt-nix"
         ]
       },
       "locked": {
-        "lastModified": 1708342507,
-        "narHash": "sha256-KoaAog/peCdkrtapUPq7F9aneJLXZMwo6CCcQ3+OtOA=",
+        "lastModified": 1708395692,
+        "narHash": "sha256-smf0VmxGbjJDZqKvxxG3ZVqubgbVwAWG26wPo+BT/A0=",
         "owner": "adisbladis",
         "repo": "mdbook-nixdoc",
-        "rev": "ce2d327032fb3d6f20144a54e7dc1195c108a1b1",
+        "rev": "d6a71b114b9221c0b4f20d31b81766d072cc26be",
         "type": "github"
       },
       "original": {
@@ -197,16 +153,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707689078,
-        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
+        "lastModified": 1708294118,
+        "narHash": "sha256-evZzmLW7qoHXf76VCepvun1esZDxHfVRFUJtumD7L2M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
+        "rev": "e0da498ad77ac8909a980f07eff060862417ccf7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -227,37 +183,18 @@
         "type": "github"
       }
     },
-    "proc-flake": {
-      "locked": {
-        "lastModified": 1692742849,
-        "narHash": "sha256-Nv8SOX+O6twFfPnA9BfubbPLZpqc+UeK6JvIWnWkdb0=",
-        "owner": "srid",
-        "repo": "proc-flake",
-        "rev": "25291b6e3074ad5dd573c1cb7d96110a9591e10f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "proc-flake",
-        "type": "github"
-      }
-    },
     "pyproject-nix": {
       "inputs": {
-        "flake-parts": "flake-parts",
-        "flake-root": "flake-root",
         "mdbook-nixdoc": "mdbook-nixdoc",
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs_2",
-        "proc-flake": "proc-flake",
-        "treefmt-nix": "treefmt-nix"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1708343936,
-        "narHash": "sha256-hGHkADEDOTFLF8Ik9b34nq8vb2FGAhqY1arxPUoXehc=",
+        "lastModified": 1708414356,
+        "narHash": "sha256-neHF92cht4G94Ye1j9YgLeqdE0dGL920lQQMLTqNm9A=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "753aca9888ed5e3bb459826ba916daa24a833d82",
+        "rev": "f75d39ce888632500bf4cff2197784929d3ed265",
         "type": "github"
       },
       "original": {
@@ -268,14 +205,14 @@
     },
     "pyproject-nix_2": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "mdbook-nixdoc": "mdbook-nixdoc_2",
         "nix-github-actions": "nix-github-actions_2",
         "nixpkgs": [
           "zephyr-nix",
           "nixpkgs"
         ],
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
         "lastModified": 1708398443,
@@ -356,27 +293,6 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "pyproject-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1702979157,
-        "narHash": "sha256-RnFBbLbpqtn4AoJGXKevQMCGhra4h6G2MPcuTSZZQ+g=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "2961375283668d867e64129c22af532de8e77734",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_2": {
-      "inputs": {
-        "nixpkgs": [
           "zephyr-nix",
           "pyproject-nix",
           "nixpkgs"
@@ -422,11 +338,11 @@
     "zephyr": {
       "flake": false,
       "locked": {
-        "lastModified": 1707895510,
-        "narHash": "sha256-NqDJH//TfEFqq+3UfeuvuJh0h/UmMgXwOOoNxwXjJwo=",
+        "lastModified": 1708470279,
+        "narHash": "sha256-rEWA+154sbvDF1gVPLqXWWcOr2rfAplYvRvsxvkQg+U=",
         "owner": "tiacsys",
         "repo": "zephyr",
-        "rev": "9ec754d9e6aab99678e3a88d87d9cb21579f8608",
+        "rev": "53f527cc2dc322302a11e2a524126e62a4dc6834",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708294118,
-        "narHash": "sha256-evZzmLW7qoHXf76VCepvun1esZDxHfVRFUJtumD7L2M=",
+        "lastModified": 1708979614,
+        "narHash": "sha256-FWLWmYojIg6TeqxSnHkKpHu5SGnFP5um1uUjH+wRV6g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e0da498ad77ac8909a980f07eff060862417ccf7",
+        "rev": "b7ee09cf5614b02d289cd86fcfa6f24d4e078c2a",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "zephyr": {
       "flake": false,
       "locked": {
-        "lastModified": 1708470279,
-        "narHash": "sha256-rEWA+154sbvDF1gVPLqXWWcOr2rfAplYvRvsxvkQg+U=",
+        "lastModified": 1709120303,
+        "narHash": "sha256-UmHHyhbGmmdZGFbxu3J8tBGZdXVMDOFikqKVUWRHgIE=",
         "owner": "tiacsys",
         "repo": "zephyr",
-        "rev": "53f527cc2dc322302a11e2a524126e62a4dc6834",
+        "rev": "ff8c8923aefad2de2a8371f8579e5f2523d3536e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,466 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "zephyr-nix",
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1692742795,
+        "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "d9a70d9c7a5fd7f3258ccf48da9335e9b47c3937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "mdbook-nixdoc": {
+      "inputs": {
+        "flake-parts": [
+          "pyproject-nix",
+          "flake-parts"
+        ],
+        "nix-github-actions": [
+          "pyproject-nix",
+          "nix-github-actions"
+        ],
+        "nixpkgs": [
+          "pyproject-nix",
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "pyproject-nix",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708342507,
+        "narHash": "sha256-KoaAog/peCdkrtapUPq7F9aneJLXZMwo6CCcQ3+OtOA=",
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "rev": "ce2d327032fb3d6f20144a54e7dc1195c108a1b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "type": "github"
+      }
+    },
+    "mdbook-nixdoc_2": {
+      "inputs": {
+        "nix-github-actions": [
+          "zephyr-nix",
+          "pyproject-nix",
+          "nix-github-actions"
+        ],
+        "nixpkgs": [
+          "zephyr-nix",
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708395692,
+        "narHash": "sha256-smf0VmxGbjJDZqKvxxG3ZVqubgbVwAWG26wPo+BT/A0=",
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "rev": "d6a71b114b9221c0b4f20d31b81766d072cc26be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701208414,
+        "narHash": "sha256-xrQ0FyhwTZK6BwKhahIkUVZhMNk21IEI1nUcWSONtpo=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "93e39cc1a087d65bcf7a132e75a650c44dd2b734",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-github-actions_2": {
+      "inputs": {
+        "nixpkgs": [
+          "zephyr-nix",
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701208414,
+        "narHash": "sha256-xrQ0FyhwTZK6BwKhahIkUVZhMNk21IEI1nUcWSONtpo=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "93e39cc1a087d65bcf7a132e75a650c44dd2b734",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707689078,
+        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1703255338,
+        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "proc-flake": {
+      "locked": {
+        "lastModified": 1692742849,
+        "narHash": "sha256-Nv8SOX+O6twFfPnA9BfubbPLZpqc+UeK6JvIWnWkdb0=",
+        "owner": "srid",
+        "repo": "proc-flake",
+        "rev": "25291b6e3074ad5dd573c1cb7d96110a9591e10f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "proc-flake",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "mdbook-nixdoc": "mdbook-nixdoc",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": "nixpkgs_2",
+        "proc-flake": "proc-flake",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1708343936,
+        "narHash": "sha256-hGHkADEDOTFLF8Ik9b34nq8vb2FGAhqY1arxPUoXehc=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "753aca9888ed5e3bb459826ba916daa24a833d82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_2": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "mdbook-nixdoc": "mdbook-nixdoc_2",
+        "nix-github-actions": "nix-github-actions_2",
+        "nixpkgs": [
+          "zephyr-nix",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1708398443,
+        "narHash": "sha256-hK1nTAzhqM0C3gxAexLS5uvHa3aA4/ReGFxoVVX6qR8=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "b8a5076ab323a63035dc0fb7b622109a52585c14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "python-deps": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708425171,
+        "narHash": "sha256-+KbQNk1RzW1Q5EvnB9q/B7H23NQoO3VLd/bDlTOrvyk=",
+        "owner": "irockasingranite",
+        "repo": "bridle-python-deps",
+        "rev": "d779b4e36484adb65a814d1498efc369aac57d38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "irockasingranite",
+        "repo": "bridle-python-deps",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix",
+        "python-deps": "python-deps",
+        "west2nix": "west2nix",
+        "zephyr": "zephyr",
+        "zephyr-nix": "zephyr-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1702979157,
+        "narHash": "sha256-RnFBbLbpqtn4AoJGXKevQMCGhra4h6G2MPcuTSZZQ+g=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "2961375283668d867e64129c22af532de8e77734",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "zephyr-nix",
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1702979157,
+        "narHash": "sha256-RnFBbLbpqtn4AoJGXKevQMCGhra4h6G2MPcuTSZZQ+g=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "2961375283668d867e64129c22af532de8e77734",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "west2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "zephyr-nix": [
+          "zephyr-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1707272336,
+        "narHash": "sha256-bFJMr8qMUmxmnqvVIc0IZGmSg64uceRvh/PxwI2Kueo=",
+        "owner": "adisbladis",
+        "repo": "west2nix",
+        "rev": "6d8d3558c42144270b534af39a00efe2f19cc278",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "west2nix",
+        "type": "github"
+      }
+    },
+    "zephyr": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1707895510,
+        "narHash": "sha256-NqDJH//TfEFqq+3UfeuvuJh0h/UmMgXwOOoNxwXjJwo=",
+        "owner": "tiacsys",
+        "repo": "zephyr",
+        "rev": "9ec754d9e6aab99678e3a88d87d9cb21579f8608",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiacsys",
+        "ref": "main",
+        "repo": "zephyr",
+        "type": "github"
+      }
+    },
+    "zephyr-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix_2",
+        "zephyr": [
+          "zephyr"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708401020,
+        "narHash": "sha256-nx3ZKpwzZS2LNPMRiapkxWPWEYKImjSR/rNPNMbJdcY=",
+        "owner": "adisbladis",
+        "repo": "zephyr-nix",
+        "rev": "6ad6ae9ed9b8d4684dd37d4bf390bdd05a810a98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "zephyr-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,37 +1,15 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "zephyr-nix",
-          "pyproject-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1701473968,
-        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -116,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701208414,
-        "narHash": "sha256-xrQ0FyhwTZK6BwKhahIkUVZhMNk21IEI1nUcWSONtpo=",
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "93e39cc1a087d65bcf7a132e75a650c44dd2b734",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
         "type": "github"
       },
       "original": {
@@ -153,11 +131,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708979614,
-        "narHash": "sha256-FWLWmYojIg6TeqxSnHkKpHu5SGnFP5um1uUjH+wRV6g=",
+        "lastModified": 1709569716,
+        "narHash": "sha256-iOR44RU4jQ+YPGrn+uQeYAp7Xo7Z/+gT+wXJoGxxLTY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7ee09cf5614b02d289cd86fcfa6f24d4e078c2a",
+        "rev": "617579a787259b9a6419492eaac670a5f7663917",
         "type": "github"
       },
       "original": {
@@ -169,11 +147,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703255338,
-        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
+        "lastModified": 1709479366,
+        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
+        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
         "type": "github"
       },
       "original": {
@@ -190,11 +168,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1708414356,
-        "narHash": "sha256-neHF92cht4G94Ye1j9YgLeqdE0dGL920lQQMLTqNm9A=",
+        "lastModified": 1709593159,
+        "narHash": "sha256-mPZaI2ctBNP78n5qTa5o+zzK54bN4gt9R7YyIfO7mgU=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "f75d39ce888632500bf4cff2197784929d3ed265",
+        "rev": "5ece746db4c561fdb9cd18575adc7a2a1a6026ed",
         "type": "github"
       },
       "original": {
@@ -205,21 +183,19 @@
     },
     "pyproject-nix_2": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "mdbook-nixdoc": "mdbook-nixdoc_2",
         "nix-github-actions": "nix-github-actions_2",
         "nixpkgs": [
           "zephyr-nix",
           "nixpkgs"
-        ],
-        "treefmt-nix": "treefmt-nix"
+        ]
       },
       "locked": {
-        "lastModified": 1708398443,
-        "narHash": "sha256-hK1nTAzhqM0C3gxAexLS5uvHa3aA4/ReGFxoVVX6qR8=",
+        "lastModified": 1708414356,
+        "narHash": "sha256-neHF92cht4G94Ye1j9YgLeqdE0dGL920lQQMLTqNm9A=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "b8a5076ab323a63035dc0fb7b622109a52585c14",
+        "rev": "f75d39ce888632500bf4cff2197784929d3ed265",
         "type": "github"
       },
       "original": {
@@ -290,28 +266,6 @@
         "type": "github"
       }
     },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "zephyr-nix",
-          "pyproject-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1702979157,
-        "narHash": "sha256-RnFBbLbpqtn4AoJGXKevQMCGhra4h6G2MPcuTSZZQ+g=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "2961375283668d867e64129c22af532de8e77734",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
     "west2nix": {
       "inputs": {
         "nixpkgs": [
@@ -363,11 +317,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708401020,
-        "narHash": "sha256-nx3ZKpwzZS2LNPMRiapkxWPWEYKImjSR/rNPNMbJdcY=",
+        "lastModified": 1709345571,
+        "narHash": "sha256-2MzrVPi0GFFtWNqc7i7Vc5MYqUz31HKw8KSKDf6X3m0=",
         "owner": "adisbladis",
         "repo": "zephyr-nix",
-        "rev": "6ad6ae9ed9b8d4684dd37d4bf390bdd05a810a98",
+        "rev": "311d2ad38ca29fedecd3201d9b7fd81848d44895",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -338,16 +338,16 @@
     "zephyr": {
       "flake": false,
       "locked": {
-        "lastModified": 1709120303,
-        "narHash": "sha256-UmHHyhbGmmdZGFbxu3J8tBGZdXVMDOFikqKVUWRHgIE=",
+        "lastModified": 1708734632,
+        "narHash": "sha256-iwEXEIA63JWSB6GcTNHHMZAEfMEwEfqcIWetF7VD2tU=",
         "owner": "tiacsys",
         "repo": "zephyr",
-        "rev": "ff8c8923aefad2de2a8371f8579e5f2523d3536e",
+        "rev": "468eb56cf242eedba62006ee758700ee6148763f",
         "type": "github"
       },
       "original": {
         "owner": "tiacsys",
-        "ref": "main",
+        "ref": "v3.6-branch",
         "repo": "zephyr",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "A flake for working with Bridle";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+
+    zephyr = {
+      url = "github:tiacsys/zephyr/main";
+      flake = false;
+    };
+
+    zephyr-nix = {
+      url = "github:adisbladis/zephyr-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.zephyr.follows = "zephyr";
+    };
+
+    west2nix = {
+      url = "github:adisbladis/west2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.zephyr-nix.follows = "zephyr-nix";
+    };
+
+    pyproject-nix.url = "github:nix-community/pyproject.nix";
+
+    python-deps = {
+      url = "github:irockasingranite/bridle-python-deps";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
+    (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        inherit (nixpkgs) lib;
+
+        west2nix = callPackage inputs.west2nix.lib.mkWest2nix { };
+
+        callPackage = pkgs.newScope (pkgs // {
+          bridle = self;
+          zephyr = inputs.zephyr;
+          zephyr-nix = inputs.zephyr-nix.packages.${system};
+          pyproject-nix = inputs.pyproject-nix;
+          pythonEnv = callPackage ./python.nix {
+            python-deps = inputs.python-deps.packages.${system};
+          };
+          west2nixHook = west2nix.mkWest2nixHook {
+            manifest = ./west2nix.toml;
+          };
+        });
+
+      in {
+        formatter = pkgs.nixfmt;
+
+        packages.west2nix = inputs.west2nix.packages.${system}.default;
+
+        devShells.default = callPackage ./shell.nix { };
+      }));
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
 
     zephyr = {
-      url = "github:tiacsys/zephyr/main";
+      type = "github";
+      owner = "tiacsys";
+      repo = "zephyr";
+      ref = "v3.6-branch";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -57,5 +57,7 @@
         packages.west2nix = inputs.west2nix.packages.${system}.default;
 
         devShells.default = callPackage ./shell.nix { };
+
+        packages.doc = callPackage ./doc.nix { };
       }));
 }

--- a/python.nix
+++ b/python.nix
@@ -1,0 +1,63 @@
+{ python3
+, zephyr
+, bridle
+, python-deps
+, pyproject-nix
+, clang-tools
+, gitlint
+, lib
+}:
+
+let
+
+  # Create a python whose `withPackages` knows about some extra stuff we need
+  python = python3.override {
+    self = python;
+    packageOverrides = final: prev: {
+      # HACK: Zephyr uses pypi to install non-Python deps
+      clang-format = clang-tools;
+      inherit gitlint;
+
+      # Extra python packages that aren't in nixpkgs
+      inherit (python-deps)
+        pydebuggerconfig
+        pyedbglib
+        pykitinfo
+        pymcuprog
+        sphinx-tsn-theme
+        sphinxcontrib-svg2pdfconverter
+        sphinx-csv-filter;
+    };
+  };
+
+  # Parse requirements.txt files into pyproject-nix projects
+  zephyr-project = pyproject-nix.lib.project.loadRequirementsTxt {
+    requirements = zephyr + "/scripts/requirements.txt";
+  };
+
+  bridle-project = pyproject-nix.lib.project.loadRequirementsTxt {
+    requirements = bridle + "/scripts/requirements.txt";
+  };
+
+  # Can't validate the combined packages sets, but we can at least check for
+  # conflicts within each subset
+  invalidConstraints = zephyr-project.validators.validateVersionConstraints { inherit python; }
+    // bridle-project.validators.validateVersionConstraints { inherit python; };
+
+in
+lib.warnIf
+  (invalidConstraints != { })
+  "pythonEnv: Found invalid Python constraints for: ${builtins.toJSON (lib.attrNames invalidConstraints)}"
+  (python.buildEnv.override {
+    extraLibs = (bridle-project.renderers.withPackages {
+      inherit python;
+      # Nest one project's withPackages within the other to get a combined package
+      # set. If we want more than two, we should name these lambdas to reduce
+      # indentation.
+      extraPackages = (zephyr-project.renderers.withPackages {
+        inherit python;
+        extraPackages = ps: [ ps.west ];
+      });
+    }) python.pkgs;
+    ignoreCollisions = true;
+  })

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,29 @@
+{ lib
+, callPackage
+, pythonEnv
+, mkShell
+, zephyr
+, zephyr-nix
+, bridle
+, cmake
+, ninja
+, git
+}:
+
+mkShell {
+  packages = [
+    zephyr-nix.sdkFull
+    zephyr-nix.hosttools-nix
+    pythonEnv
+    cmake
+    ninja
+    git
+  ];
+
+  LC_ALL = "C.UTF-8"; # Needed by sphinx
+
+  shellHook = ''
+    export CMAKE_PREFIX_PATH=$(realpath ${bridle}/share/bridle-package/cmake):$CMAKE_PREFIX_PATH;
+    export CMAKE_PREFIX_PATH=$(realpath ${zephyr}/share/zephyr-package/cmake):$CMAKE_PREFIX_PATH;
+  '';
+}

--- a/west2nix.toml
+++ b/west2nix.toml
@@ -1,0 +1,442 @@
+[manifest]
+group-filter = ["-babblesim"]
+
+[[manifest.projects]]
+name = "ubxlib"
+url = "https://github.com/tiacsys/ubxlib"
+revision = "373f57933ba2fb9fbdd8166fe1d9db79a372a334"
+path = "modules/lib/ubxlib"
+
+[manifest.projects.nix]
+hash = "sha256-zv058Sz4+c4vJJe+dtqJ8B1vbTfxPym5r1nH1gyXB+U="
+
+[[manifest.projects]]
+name = "zephyr"
+url = "https://github.com/tiacsys/zephyr"
+revision = "e2d504bd2390a68981781b29db7572cc26f9188c"
+clone-depth = 5000
+west-commands = "scripts/west-commands.yml"
+
+[manifest.projects.userdata]
+west-commands-path = "scripts/west_commands"
+
+[manifest.projects.nix]
+hash = "sha256-klB4g70S577aBrgRgxXpsxpb56Gj+p78/ivyCRhnZts="
+
+[[manifest.projects]]
+name = "canopennode"
+url = "https://github.com/zephyrproject-rtos/canopennode"
+revision = "dec12fa3f0d790cafa8414a4c2930ea71ab72ffd"
+path = "modules/lib/canopennode"
+groups = ["optional"]
+
+[manifest.projects.nix]
+hash = "sha256-BbmEjeMzKznRDx329PIkmPMCGI+du6wiOj+3X7Ap1HQ="
+
+[[manifest.projects]]
+name = "chre"
+url = "https://github.com/zephyrproject-rtos/chre"
+revision = "3b32c76efee705af146124fb4190f71be5a4e36e"
+path = "modules/lib/chre"
+groups = ["optional"]
+
+[manifest.projects.nix]
+hash = "sha256-7SdP9zSKZ+6s+nkIcIbjZSnacq2/t06DiR2gcaL07T4="
+
+[[manifest.projects]]
+name = "psa-arch-tests"
+url = "https://github.com/zephyrproject-rtos/psa-arch-tests"
+revision = "2cadb02a72eacda7042505dcbdd492371e8ce024"
+path = "modules/tee/tf-m/psa-arch-tests"
+groups = ["optional"]
+
+[manifest.projects.nix]
+hash = "sha256-oYpqLIbtKsNHQ9FQjhSM8Rvd/VM4M+ETO5hum2fZVq8="
+
+[[manifest.projects]]
+name = "tf-m-tests"
+url = "https://github.com/zephyrproject-rtos/tf-m-tests"
+revision = "08a3158f0623a4205608a52d880b17ae394e31d2"
+path = "modules/tee/tf-m/tf-m-tests"
+groups = ["optional"]
+
+[manifest.projects.nix]
+hash = "sha256-wALfatKKBeUh1rLWOIxRn2/Tm0XDh34cHUA5IFybbgc="
+
+[[manifest.projects]]
+name = "cmsis"
+url = "https://github.com/zephyrproject-rtos/cmsis"
+revision = "4b96cbb174678dcd3ca86e11e1f24bc5f8726da0"
+path = "modules/hal/cmsis"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-vzCbE69wCMLIjrSz1m8yspgVCto4JSm4Qg5zY/Ozg+k="
+
+[[manifest.projects]]
+name = "edtt"
+url = "https://github.com/zephyrproject-rtos/edtt"
+revision = "64e5105ad82390164fb73fc654be3f73a608209a"
+path = "tools/edtt"
+groups = ["tools"]
+
+[manifest.projects.nix]
+hash = "sha256-AK4zYIHn0XnkKDl9YGo1lV/2Ea6wLw0rJbzpMA8JZ9w="
+
+[[manifest.projects]]
+name = "fatfs"
+url = "https://github.com/zephyrproject-rtos/fatfs"
+revision = "427159bf95ea49b7680facffaa29ad506b42709b"
+path = "modules/fs/fatfs"
+groups = ["fs"]
+
+[manifest.projects.nix]
+hash = "sha256-5l3hJazG8BoLZ0QxfSFc98uKArIGAFD1P8D6tsKMRt4="
+
+[[manifest.projects]]
+name = "hal_altera"
+url = "https://github.com/zephyrproject-rtos/hal_altera"
+revision = "0d225ddd314379b32355a00fb669eacf911e750d"
+path = "modules/hal/altera"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-H2C+3ASsC5O/mA+O5EJqfoJgx0BhSN0W3OhWNHVQxRU="
+
+[[manifest.projects]]
+name = "hal_atmel"
+url = "https://github.com/zephyrproject-rtos/hal_atmel"
+revision = "aad79bf530b69b72712d18873df4120ad052d921"
+path = "modules/hal/atmel"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-9mJjeX9l7orJvYXjW46YROTPvm389KKF3s1XYj7g+VM="
+
+[[manifest.projects]]
+name = "hal_espressif"
+url = "https://github.com/zephyrproject-rtos/hal_espressif"
+revision = "67fa60bdffca7ba8ed199aecfaa26f485f24878b"
+path = "modules/hal/espressif"
+west-commands = "west/west-commands.yml"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-RbR5+SK3Ijn9f/VQ8FzxVy/VYPcP22iVAaIjpaYvV0U="
+
+[[manifest.projects]]
+name = "hal_gigadevice"
+url = "https://github.com/zephyrproject-rtos/hal_gigadevice"
+revision = "2994b7dde8b0b0fa9b9c0ccb13474b6a486cddc3"
+path = "modules/hal/gigadevice"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-Cgcc+7tJy0ryQG4ynrlv7OmNe3OW2kMx1mStGROgA5o="
+
+[[manifest.projects]]
+name = "hal_infineon"
+url = "https://github.com/zephyrproject-rtos/hal_infineon"
+revision = "69c883d3bd9fac8a18dd8384624b8c472a68d06f"
+path = "modules/hal/infineon"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-v6Vvw/h007KEznd1/2tbHg1P06yXX7flPn9mLaWm0CU="
+
+[[manifest.projects]]
+name = "hal_microchip"
+url = "https://github.com/zephyrproject-rtos/hal_microchip"
+revision = "5d079f1683a00b801373bbbbf5d181d4e33b30d5"
+path = "modules/hal/microchip"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-CJdNHsowN9WsKSHekypUdeJvOJ19/0PHZU874CXVaoU="
+
+[[manifest.projects]]
+name = "hal_nordic"
+url = "https://github.com/zephyrproject-rtos/hal_nordic"
+revision = "dce8519f7da37b0a745237679fd3f88250b495ff"
+path = "modules/hal/nordic"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-cdZIYWc3uCeseGkJoEFxE2iZlfSnlpaVhNUo1g0+4vM="
+
+[[manifest.projects]]
+name = "hal_nuvoton"
+url = "https://github.com/zephyrproject-rtos/hal_nuvoton"
+revision = "68a91bb343ff47e40dbd9189a7d6e3ee801a7135"
+path = "modules/hal/nuvoton"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-oilM3sRalL9ruIIukM3G/Vg6dI/Ahwma3kUHf7x/6wE="
+
+[[manifest.projects]]
+name = "hal_nxp"
+url = "https://github.com/zephyrproject-rtos/hal_nxp"
+revision = "d45b14c198d778658b7853b48378d2e132a6c4be"
+path = "modules/hal/nxp"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-fHnZ775PZ7jwpNmrW8n/+j0vE2AnV8OsX4lm0glr1Fc="
+
+[[manifest.projects]]
+name = "hal_openisa"
+url = "https://github.com/zephyrproject-rtos/hal_openisa"
+revision = "eabd530a64d71de91d907bad257cd61aacf607bc"
+path = "modules/hal/openisa"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-krI/9sr57ZjerDKb9lQvIOD+q6vfiXqRGqV7cbW9Bqs="
+
+[[manifest.projects]]
+name = "hal_quicklogic"
+url = "https://github.com/zephyrproject-rtos/hal_quicklogic"
+revision = "b3a66fe6d04d87fd1533a5c8de51d0599fcd08d0"
+path = "modules/hal/quicklogic"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-XpPROaiZN0KRxQCtEOYaXSEBtxAo+atnH1ytOMXpYUI="
+
+[[manifest.projects]]
+name = "hal_renesas"
+url = "https://github.com/zephyrproject-rtos/hal_renesas"
+revision = "0b1f2fdb99d6386f125a8dba72083e3c56aecc2b"
+path = "modules/hal/renesas"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-BPvUTX3FhSz8yKOMDjOLGqGisKV69AMwlYxwJ622anY="
+
+[[manifest.projects]]
+name = "hal_rpi_pico"
+url = "https://github.com/zephyrproject-rtos/hal_rpi_pico"
+revision = "fba7162cc7bee06d0149622bbcaac4e41062d368"
+path = "modules/hal/rpi_pico"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-qv0GPlBQ0np8a0obi5pt6LyxKiTIqWEhoG7vI4jLAwc="
+
+[[manifest.projects]]
+name = "hal_silabs"
+url = "https://github.com/zephyrproject-rtos/hal_silabs"
+revision = "b11b29167f3f9a0fd0c34a8eeeb36b0c1d218917"
+path = "modules/hal/silabs"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-AqYwRoKW1FJFJYc/J3KK84lQpy6LxFOPUXDXrDIYUZs="
+
+[[manifest.projects]]
+name = "hal_st"
+url = "https://github.com/zephyrproject-rtos/hal_st"
+revision = "0643d20ae85b32c658ad11036f7c964a860ddefe"
+path = "modules/hal/st"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-b/uaXxebfasYCS1rEnEqEoHwH7CYywg6HxaDntJ9mKg="
+
+[[manifest.projects]]
+name = "hal_stm32"
+url = "https://github.com/zephyrproject-rtos/hal_stm32"
+revision = "60c9634f61c697e1c310ec648d33529712806069"
+path = "modules/hal/stm32"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-uvkOKfVMfYql0YaGLOJQQboqiXKEDo19lV6x23XyUYE="
+
+[[manifest.projects]]
+name = "hal_telink"
+url = "https://github.com/zephyrproject-rtos/hal_telink"
+revision = "38573af589173259801ae6c2b34b7d4c9e626746"
+path = "modules/hal/telink"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-H50e/YCXk1oa7MSyW1czZ09S4GOhp7e2BDIKyr/Fn5o="
+
+[[manifest.projects]]
+name = "hal_ti"
+url = "https://github.com/zephyrproject-rtos/hal_ti"
+revision = "b85f86e51fc4d47c4c383d320d64d52d4d371ae4"
+path = "modules/hal/ti"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-NaXcMhV3GG+BexuQx3S4vtEchLgKasMlo1NJ+V56JBk="
+
+[[manifest.projects]]
+name = "hal_xtensa"
+url = "https://github.com/zephyrproject-rtos/hal_xtensa"
+revision = "08325d6fb7190a105f5382d35e64ed2812c57cf4"
+path = "modules/hal/xtensa"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-9vihVhCzVGG+CYrN9pNtBUMM3WfFwrgI8brq0zGILBI="
+
+[[manifest.projects]]
+name = "libmetal"
+url = "https://github.com/zephyrproject-rtos/libmetal"
+revision = "243eed541b9c211a2ce8841c788e62ddce84425e"
+path = "modules/hal/libmetal"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-wCsYllPeDKx4P5gBGEFDcY4QNbMdwrd+5h5GZ8tEsJM="
+
+[[manifest.projects]]
+name = "liblc3"
+url = "https://github.com/zephyrproject-rtos/liblc3"
+revision = "1a5938ebaca4f13fe79ce074f5dee079783aa29f"
+path = "modules/lib/liblc3"
+
+[manifest.projects.nix]
+hash = "sha256-nQJgF/cWoCx5TkX4xOaLB9SzvhVXPY29bLh7UwPMWEE="
+
+[[manifest.projects]]
+name = "littlefs"
+url = "https://github.com/zephyrproject-rtos/littlefs"
+revision = "408c16a909dd6cf128874a76f21c793798c9e423"
+path = "modules/fs/littlefs"
+groups = ["fs"]
+
+[manifest.projects.nix]
+hash = "sha256-r0YCwuH5RQill5xtjPUV5NUsKqs3U0k8I2W5knKXVb8="
+
+[[manifest.projects]]
+name = "loramac-node"
+url = "https://github.com/zephyrproject-rtos/loramac-node"
+revision = "842413c5fb98707eb5f26e619e8e792453877897"
+path = "modules/lib/loramac-node"
+
+[manifest.projects.nix]
+hash = "sha256-5/qUGojHZVNoT7SOsTGNA/pFCuOGrPzibv0MoJdq/rk="
+
+[[manifest.projects]]
+name = "lvgl"
+url = "https://github.com/zephyrproject-rtos/lvgl"
+revision = "2b76c641749725ac90c6ac7959ca7718804cf356"
+path = "modules/lib/gui/lvgl"
+
+[manifest.projects.nix]
+hash = "sha256-X3DOhGCMFb03eubcc5VcHRPt1RKWzyviaTUh1HXzGDc="
+
+[[manifest.projects]]
+name = "mbedtls"
+url = "https://github.com/zephyrproject-rtos/mbedtls"
+revision = "6ec4abdcda78dfc47315af568f93e5ad4398dea0"
+path = "modules/crypto/mbedtls"
+groups = ["crypto"]
+
+[manifest.projects.nix]
+hash = "sha256-r4CcM/VuG9JJavT+YOn5EEFWTvEDnjPAy6H+UkIeZ6s="
+
+[[manifest.projects]]
+name = "mcuboot"
+url = "https://github.com/zephyrproject-rtos/mcuboot"
+revision = "a4eda30f5b0cfd0cf15512be9dcd559239dbfc91"
+path = "bootloader/mcuboot"
+
+[manifest.projects.nix]
+hash = "sha256-m9sy2QxHIkXF7vX1FNq+CjOMzchbEeQmcTnaPijpl5A="
+
+[[manifest.projects]]
+name = "mipi-sys-t"
+url = "https://github.com/zephyrproject-rtos/mipi-sys-t"
+revision = "a819419603a2dfcb47f7f39092e1bc112e45d1ef"
+path = "modules/debug/mipi-sys-t"
+groups = ["debug"]
+
+[manifest.projects.nix]
+hash = "sha256-O5BkXoaCj3xxRsaoarDcCSxhovhH0ihvmY0COy6BQK0="
+
+[[manifest.projects]]
+name = "net-tools"
+url = "https://github.com/zephyrproject-rtos/net-tools"
+revision = "3a677d355cc7f73e444801a6280d0ccec80a1957"
+path = "tools/net-tools"
+groups = ["tools"]
+
+[manifest.projects.nix]
+hash = "sha256-YlaszC8BNXCzSGAusiYhEzzRs55gnWykN/3zb0MGA7w="
+
+[[manifest.projects]]
+name = "open-amp"
+url = "https://github.com/zephyrproject-rtos/open-amp"
+revision = "da78aea63159771956fe0c9263f2e6985b66e9d5"
+path = "modules/lib/open-amp"
+
+[manifest.projects.nix]
+hash = "sha256-7yae0X7zqDPA4CUfGU3LgNBh7qyKGIPLUv6dn/d65Fg="
+
+[[manifest.projects]]
+name = "openthread"
+url = "https://github.com/zephyrproject-rtos/openthread"
+revision = "7761b81d23b10b3d5ee21b8504c67535cde10896"
+path = "modules/lib/openthread"
+
+[manifest.projects.nix]
+hash = "sha256-/GKaDl/mlBwsuRq0RNnV2vzXRC6pfz1CwHPm9RfyzwU="
+
+[[manifest.projects]]
+name = "picolibc"
+url = "https://github.com/zephyrproject-rtos/picolibc"
+revision = "764ef4e401a8f4c6a86ab723533841f072885a5b"
+path = "modules/lib/picolibc"
+
+[manifest.projects.nix]
+hash = "sha256-5W/+vorhOP/MD19JYzHJfZTkWMM7sKUQqzTDA/7rxZs="
+
+[[manifest.projects]]
+name = "segger"
+url = "https://github.com/zephyrproject-rtos/segger"
+revision = "9d0191285956cef43daf411edc2f1a7788346def"
+path = "modules/debug/segger"
+groups = ["debug"]
+
+[manifest.projects.nix]
+hash = "sha256-9nt0z674ubxxvIANPMf82Qf7KsOwR3Hg8wYAK5r/i4c="
+
+[[manifest.projects]]
+name = "tinycrypt"
+url = "https://github.com/zephyrproject-rtos/tinycrypt"
+revision = "3e9a49d2672ec01435ffbf0d788db6d95ef28de0"
+path = "modules/crypto/tinycrypt"
+groups = ["crypto"]
+
+[manifest.projects.nix]
+hash = "sha256-5gtZbZNx+D/EUkyYk7rPtcxBZaNs4IFGTP/7IXzCoqU="
+
+[[manifest.projects]]
+name = "trusted-firmware-m"
+url = "https://github.com/zephyrproject-rtos/trusted-firmware-m"
+revision = "0b898c9b72171b0a260c0bb64a92ea4713f9e931"
+path = "modules/tee/tf-m/trusted-firmware-m"
+groups = ["tee"]
+
+[manifest.projects.nix]
+hash = "sha256-oVDl4uE4fPg98HjjQFFl/kNH90w7oulIHCB/84voOYQ="
+
+[[manifest.projects]]
+name = "trusted-firmware-a"
+url = "https://github.com/zephyrproject-rtos/trusted-firmware-a"
+revision = "421dc050278287839f5c70019bd6aec617f2bbdb"
+path = "modules/tee/tf-a/trusted-firmware-a"
+groups = ["tee"]
+
+[manifest.projects.nix]
+hash = "sha256-XsjRUe0Cr5bd+rOzoS+Hquh9k2nKwDKt2+up24aCOgk="
+
+[manifest.self]
+path = "bridle"
+west-commands = "scripts/west-commands.yml"

--- a/west2nix.toml
+++ b/west2nix.toml
@@ -4,16 +4,16 @@ group-filter = ["-babblesim"]
 [[manifest.projects]]
 name = "ubxlib"
 url = "https://github.com/tiacsys/ubxlib"
-revision = "373f57933ba2fb9fbdd8166fe1d9db79a372a334"
+revision = "3537ea286e9e5ed88818b6a2eda04a93484e9e03"
 path = "modules/lib/ubxlib"
 
 [manifest.projects.nix]
-hash = "sha256-zv058Sz4+c4vJJe+dtqJ8B1vbTfxPym5r1nH1gyXB+U="
+hash = "sha256-U5MzTFexIGGy4ttvf7GBQ6W/p+uGTwFKrIvY+lYhZIg="
 
 [[manifest.projects]]
 name = "zephyr"
 url = "https://github.com/tiacsys/zephyr"
-revision = "e2d504bd2390a68981781b29db7572cc26f9188c"
+revision = "6c93afc3d2572a8f3f4aed0c81d80176f6bbb2ff"
 clone-depth = 5000
 west-commands = "scripts/west-commands.yml"
 
@@ -21,7 +21,7 @@ west-commands = "scripts/west-commands.yml"
 west-commands-path = "scripts/west_commands"
 
 [manifest.projects.nix]
-hash = "sha256-klB4g70S577aBrgRgxXpsxpb56Gj+p78/ivyCRhnZts="
+hash = "sha256-WsAK7oFvYPPU1zIxelnfARKj82XdtJt5ndKOTaXJZrY="
 
 [[manifest.projects]]
 name = "canopennode"

--- a/west2nix.toml
+++ b/west2nix.toml
@@ -4,11 +4,11 @@ group-filter = ["-babblesim"]
 [[manifest.projects]]
 name = "ubxlib"
 url = "https://github.com/tiacsys/ubxlib"
-revision = "3537ea286e9e5ed88818b6a2eda04a93484e9e03"
+revision = "c564a1ac88e62117d88277e4e74513de50a95c45"
 path = "modules/lib/ubxlib"
 
 [manifest.projects.nix]
-hash = "sha256-U5MzTFexIGGy4ttvf7GBQ6W/p+uGTwFKrIvY+lYhZIg="
+hash = "sha256-Qx9S7l0q1d6vJbqxRgyplqFr+seH/QybHYs84EN2Jbo="
 
 [[manifest.projects]]
 name = "zephyr"


### PR DESCRIPTION
This PR adds a [nix flake](https://nixos.wiki/wiki/Flakes) definition, which provides as output a devshell, i.e. a development environment containing all necessary tools and libraries to work with bridle.

This (optionally) removes the dependency on any distribution packages installed via `apt` (or equivalent) apart from Nix itself, and removes the need for `pip` and `virtualenv` entirely.

To evaluate the flake, install Nix (the package manager), e.g. by `apt install nix`. Then either add `experimental-features = nix-command flakes` to `~/.config/nix/nix.conf`, or add `--experimental-features 'nix-command flakes'` to any `nix` command.
After that, simply navigate to the bridle directory, and run `nix develop` to enter the devshell environment.

As a proof-of-concept, the PR also includes a subflake `nix-workspace`, which provides a fully fetched and initialized west workspace. This can be used to define derivations that include west commands, as demonstrated by the `bridle-doc` package also provided by the main flake. This makes it possible to generate the full documentation set by running `nix build .#bridle-doc`, also without installing any further dependencies or creating a local workspace.

This subflake is auto-generated via a python script, also currently located in `nix-workspace`. This script parses the project's west manifest and generates corresponding flake inputs, which can then be locked. Re-generating the subflake is only needed after manifest changes, otherwise upstream changes will be brought in via `nix flake update` as normal.

Note that the setup still suffers from an issue with subflakes, which requires building the required outputs *from the subflake* at least once to create a reference in the local nix store, before the main flake can reference it. In this case this means running `nix build nix-workspace#workspace`.