### PR TITLE
Porting to latest ws2812 driver over RPi Pico PIO

### DIFF
--- a/boards/arm/cytron_rp2040/makerpi_led_ws2812.dtsi
+++ b/boards/arm/cytron_rp2040/makerpi_led_ws2812.dtsi
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	pio-ws2812 {
-		compatible = "raspberrypi,pico-pio-ws2812";
+		compatible = "worldsemi,ws2812-rpi_pico-pio";
 		status = "okay";
 
 		pinctrl-0 = <&pio0_ws2812_makerpi>;
@@ -25,7 +25,6 @@
 		bit-waveform = <3>, <3>, <4>;
 
 		led_strip: ws2812 {
-			compatible = "worldsemi,ws2812-rpi_pico-pio";
 			status = "okay";
 
 			chain-length = <2>;

--- a/boards/arm/waveshare_rp2040/rp2040mini_led_ws2812.dtsi
+++ b/boards/arm/waveshare_rp2040/rp2040mini_led_ws2812.dtsi
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	pio-ws2812 {
-		compatible = "raspberrypi,pico-pio-ws2812";
+		compatible = "worldsemi,ws2812-rpi_pico-pio";
 		status = "okay";
 
 		pinctrl-0 = <&pio0_ws2812_mini_default>;
@@ -25,7 +25,6 @@
 		bit-waveform = <3>, <3>, <4>;
 
 		led_strip: ws2812 {
-			compatible = "worldsemi,ws2812-rpi_pico-pio";
 			status = "okay";
 
 			chain-length = <1>;

--- a/boards/arm/waveshare_rp2040/rpipico_led_ws2812.dtsi
+++ b/boards/arm/waveshare_rp2040/rpipico_led_ws2812.dtsi
@@ -17,7 +17,7 @@
 	status = "okay";
 
 	pio-ws2812 {
-		compatible = "raspberrypi,pico-pio-ws2812";
+		compatible = "worldsemi,ws2812-rpi_pico-pio";
 		status = "okay";
 
 		pinctrl-0 = <&pio0_ws2812_pico_default>;
@@ -25,7 +25,6 @@
 		bit-waveform = <3>, <3>, <4>;
 
 		led_strip: ws2812 {
-			compatible = "worldsemi,ws2812-rpi_pico-pio";
 			status = "okay";
 
 			chain-length = <1>;

--- a/doc/bridle/releases/release-notes-3.6.0.rst
+++ b/doc/bridle/releases/release-notes-3.6.0.rst
@@ -163,6 +163,8 @@ Change log
 * Add the new *PWM Servomotor Preset Snippet (pwm-servo)* for quite board
   specific preperations of the standard Zephyr Servomotor sample. Add support
   for the following boards:
+* Update GPIO to use ``DT_HAS_<compat>_ENABLED`` Kconfig symbol to expose the
+  driver and enable it by default based on devicetree.
 
   * Cytron Maker Pi RP2040
 

--- a/drivers/gpio/Kconfig.pca9554
+++ b/drivers/gpio/Kconfig.pca9554
@@ -5,6 +5,8 @@
 
 menuconfig GPIO_PCA9554
 	bool "PCA9554 I2C-based GPIO chip"
+	default y
+	depends on DT_HAS_NXP_PCA9554_ENABLED
 	depends on I2C
 	help
 	  Enable driver for PCA9554 I2C-based GPIO chip.

--- a/drivers/gpio/Kconfig.pca9555
+++ b/drivers/gpio/Kconfig.pca9555
@@ -5,6 +5,8 @@
 
 menuconfig GPIO_PCA9555
 	bool "PCA9555 I2C-based GPIO chip"
+	default y
+	depends on DT_HAS_NXP_PCA9555_ENABLED
 	depends on I2C
 	help
 	  Enable driver for PCA9555 I2C-based GPIO chip.


### PR DESCRIPTION
In conjunction with the latest changes at https://github.com/zephyrproject-rtos/zephyr/pull/55226, some Devicetree declarations had to be corrected. In addition, the two GPIO drivers in Bridle for PCA9554 and PCA9555 are now activated automatically.