### PR TITLE
Fix broken nightly QA test

### DIFF
--- a/boards/shields/waveshare_pico_10dof_imu_sensor/waveshare_pico_10dof_imu_sensor.dtsi
+++ b/boards/shields/waveshare_pico_10dof_imu_sensor/waveshare_pico_10dof_imu_sensor.dtsi
@@ -13,7 +13,9 @@
 		wsptdis_accel: wsptdis-accel {
 			compatible = "zephyr,sensing-phy-3d-sensor";
 			status = "disabled";
-			sensor-type = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D>;
+			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D
+					SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D
+					SENSING_SENSOR_TYPE_MOTION_MOTION_DETECTOR>;
 			friendly-name = "WSP 10-DOF IMU Shield Accelerometer";
 			minimal-interval = <625>;
 			underlying-device = <&wsptdis_sens_dof>;

--- a/boards/shields/waveshare_pico_environment_sensor/waveshare_pico_environment_sensor.overlay
+++ b/boards/shields/waveshare_pico_environment_sensor/waveshare_pico_environment_sensor.overlay
@@ -13,7 +13,9 @@
 		wspes_accel: wspes-accel {
 			compatible = "zephyr,sensing-phy-3d-sensor";
 			status = "disabled";
-			sensor-type = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D>;
+			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D
+					SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D
+					SENSING_SENSOR_TYPE_MOTION_MOTION_DETECTOR>;
 			friendly-name = "WSP Environment Shield Accelerometer";
 			minimal-interval = <625>;
 			underlying-device = <&wspes_sens_dof>;

--- a/doc/bridle/releases/release-notes-3.6.0.rst
+++ b/doc/bridle/releases/release-notes-3.6.0.rst
@@ -244,6 +244,7 @@ Issue Related Items
 
 These GitHub issues were addressed since project bootstrapping:
 
+* :github:`187` - [BUG] ubx_gnss sample fails to build
 * :github:`185` - [HW] Waveshare Pico 10-DOF IMU Sensor
 * :github:`183` - [HW] Waveshare Pico RGB LED
 * :github:`177` - [HW] Waveshare Pico Environment Sensor

--- a/samples/helloshell/boards/qemu_cortex_m0.conf
+++ b/samples/helloshell/boards/qemu_cortex_m0.conf
@@ -1,7 +1,8 @@
-# Copyright (c) 2021-2023 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 # disable components to avoid RAM overflow on BSS allocation
 CONFIG_FLASH=n
 CONFIG_FLASH_SHELL=n
 CONFIG_SENSOR_INFO=n
+CONFIG_SHELL_MINIMAL=y


### PR DESCRIPTION
With the Zephyr upstream commit f5595b4b9c3bbeb44a56d27a2854a172fc5eaad6
the new (work in progress) sensing subsystem renames property 'sensor-type'
to 'sensor-types' and change the type of this required property from
'int' to an 'array' of type values.