### PR TITLE
boards: cytron_rp2040: add gpio-line-names

### DIFF
--- a/boards/arm/cytron_rp2040/cytron_rp2040-makernano.dtsi
+++ b/boards/arm/cytron_rp2040/cytron_rp2040-makernano.dtsi
@@ -40,3 +40,40 @@
 	pinctrl-0 = <&adc_makernano>;
 	pinctrl-names = "default";
 };
+
+&gpio0 {
+	status = "okay";
+	/* namespace and positions without wired bits */
+	gpio-reserved-ranges = <10 1>, <21 1>, <23 3>;
+	gpio-line-names =
+		"AH1Q02_TX0",		/* GP0 */
+		"AH2Q01_RX0",		/* GP1 */
+		"AH5",			/* GP2 */
+		"AH6",			/* GP3 */
+		"AH7",			/* GP4 */
+		"AH8",			/* GP5 */
+		"AH9",			/* GP6 */
+		"AH10",			/* GP7 */
+		"AH11",			/* GP8 */
+		"AH12_ULED0",		/* GP9 */
+		"",	 /* not connected, GP10 */
+		"RGB_SDO1",		/* GP11 */
+		"AH23_SDA0",		/* GP12 */
+		"AH24_SCL0",		/* GP13 */
+		"AH25",			/* GP14 */
+		"AH26",			/* GP15 */
+		"AH15_SDI0",		/* GP16 */
+		"AH13_CSN0",		/* GP17 */
+		"AH16_SCK0",		/* GP18 */
+		"AH14_SDO0",		/* GP19 */
+		"UBTN0",		/* GP20 */
+		"",	 /* not connected, GP21 */
+		"BUZZER_PWM6",		/* GP22 */
+		"",	 /* not connected, GP23 */
+		"",	 /* not connected, GP24 */
+		"",	 /* not connected, GP25 */
+		"AH19Q12_SDA1",		/* GP26 */
+		"AH20Q11_SCL1",		/* GP27 */
+		"AH21_ADC2",		/* GP28 */
+		"AH22_ADC3";		/* GP29 */
+};

--- a/boards/arm/cytron_rp2040/cytron_rp2040-makerpi.dtsi
+++ b/boards/arm/cytron_rp2040/cytron_rp2040-makerpi.dtsi
@@ -40,3 +40,40 @@
 	pinctrl-0 = <&adc_makerpi>;
 	pinctrl-names = "default";
 };
+
+&gpio0 {
+	status = "okay";
+	/* namespace and positions without wired bits */
+	gpio-reserved-ranges = <19 1>, <23 3>;
+	gpio-line-names =
+		"GROVE13_TX0",		/* GP0 */
+		"GROVE14_RX0",		/* GP1 */
+		"GROVE23_SCK0",		/* GP2 */
+		"GROVE24_SDO0",		/* GP3 */
+		"GROVE33_SDI0",		/* GP4 */
+		"GROVE34_CSN0",		/* GP5 */
+		"GROVE53",		/* GP6 */
+		"GROVE73ULED0",		/* GP7 */
+		"DCM1A_PWM8",		/* GP8 */
+		"DCM1B_PWM9",		/* GP9 */
+		"DCM2A_PWM10",		/* GP10 */
+		"DCM2B_PWM11",		/* GP11 */
+		"SRVM1_PWM12",		/* GP12 */
+		"SRVM2_PWM13",		/* GP13 */
+		"SRVM3_PWM14",		/* GP14 */
+		"SRVM4_PWM15",		/* GP15 */
+		"GROVE43_SDA0",		/* GP16 */
+		"GROVE44_SCL0",		/* GP17 */
+		"RGB_PIO0",		/* GP18 */
+		"",	 /* not connected, GP19 */
+		"UBTN0",		/* GP20 */
+		"UBTN1",		/* GP21 */
+		"BUZZER_PWM6",		/* GP22 */
+		"",	 /* not connected, GP23 */
+		"",	 /* not connected, GP24 */
+		"",	 /* not connected, GP25 */
+		"GROVE54_ADC0",		/* GP26 */
+		"GROVE64_ADC1",		/* GP27 */
+		"GROVE74_ADC2",		/* GP28 */
+		"VMOTOR_ADC3";		/* GP29 */
+};


### PR DESCRIPTION
This is extends the two Cytron Maker boards with a set of fancy GPIO line names on DTS level. We'll need this for tutorials and better documentation.