### PR TITLE
major fixes and improvements

### DIFF
--- a/boards/arm/picoboy/core_oled.dtsi
+++ b/boards/arm/picoboy/core_oled.dtsi
@@ -41,8 +41,6 @@
 
 		segment-remap;
 		com-invdir;
-
-		inversion-on;
 	};
 };
 

--- a/boards/shields/rpi_pico_lcd/boards/rpipico_r3-pinctrl.dtsi
+++ b/boards/shields/rpi_pico_lcd/boards/rpipico_r3-pinctrl.dtsi
@@ -15,3 +15,6 @@
 		/* GP12: SPI1_RX not used for LCD only access */
 	};
 };
+
+/* link to pinctrl node from board extensions for rpi_pico/_w */
+spi1_pico: &spi1_default {};

--- a/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/ili9488_320x480.dtsi
+++ b/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/ili9488_320x480.dtsi
@@ -1,20 +1,18 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <freq.h>
 #include <zephyr/dt-bindings/display/ili9xxx.h>
 
-&rpipico_spi_lcd {
+&mipi_dbi {
 	ili9488_320x480: ili9488@0 {
 		compatible = "ilitek,ili9488";
-		spi-max-frequency = <DT_FREQ_M(60)>;
+		mipi-max-frequency = <DT_FREQ_M(60)>;
 		reg = <0>;
 
 		status = "disabled";
-
-		spi2mcu-shift = <16>;	/* 16-bit shifted register data */
 
 		width = <320>;
 		height = <480>;

--- a/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/ili9488_480x320.dtsi
+++ b/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/ili9488_480x320.dtsi
@@ -1,20 +1,18 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <freq.h>
 #include <zephyr/dt-bindings/display/ili9xxx.h>
 
-&rpipico_spi_lcd {
+&mipi_dbi {
 	ili9488_480x320: ili9488@0 {
 		compatible = "ilitek,ili9488";
-		spi-max-frequency = <DT_FREQ_M(60)>;
+		mipi-max-frequency = <DT_FREQ_M(60)>;
 		reg = <0>;
 
 		status = "disabled";
-
-		spi2mcu-shift = <16>;	/* 16-bit shifted register data */
 
 		width = <480>;
 		height = <320>;

--- a/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/rpipico_r3.dtsi
+++ b/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/rpipico_r3.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,25 +20,37 @@
 	//swap-xy;
 };
 
-&tsc_panel {
-	status = "okay";
-	int-gpios = <&rpipico_header 17 GPIO_ACTIVE_LOW>;	/* GP17 */
-};
-
-&lcd_backlight_en {
-	enable-gpios = <&rpipico_header 13 GPIO_ACTIVE_HIGH>;	/* GP13 */
-};
-
-&lcd_panel {
-	status = "okay";
-	reset-gpios = <&rpipico_header 15 GPIO_ACTIVE_LOW>;	/* GP15 */
-	cmd-data-gpios = <&rpipico_header 8 GPIO_ACTIVE_LOW>;	/* GP8 */
-};
-
 &rpipico_spi_lcd {
 	pinctrl-0 = <&spi1_pico>;
 	pinctrl-names = "default";
 	cs-gpios = <&rpipico_header 9 GPIO_ACTIVE_LOW>,		/* LCD: GP9 */
 		   <&rpipico_header 16 GPIO_ACTIVE_LOW>,	/* TSC: GP16 */
 		   <&rpipico_header 22 GPIO_ACTIVE_LOW>;	/* SDC: GP22 */
+};
+
+&tsc_panel {
+	status = "okay";
+	int-gpios = <&rpipico_header 17 GPIO_ACTIVE_LOW>;	/* GP17 */
+};
+
+&mipi_dbi {
+	status = "okay";
+	reset-gpios = <&rpipico_header 15 GPIO_ACTIVE_HIGH>;	/* GP15 */
+	dc-gpios = <&rpipico_header 8 GPIO_ACTIVE_HIGH>;	/* GP8 */
+	spi-dev = <&rpipico_spi_lcd>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+};
+
+&lcd_panel {
+	status = "okay";
+	//spi2mcu-shift = <16>;	/* 16-bit shifted register data */
+	/* TODO: port to new MIPI DBI API. That needs a new MIPI DBI device
+	 * interface type on Zephyr upstream: Type C, SPI with command/data
+         * selected via GPIO pin --- BUT 16 write clocks per byte. */
+};
+
+&lcd_backlight_en {
+	status = "okay";
+	enable-gpios = <&rpipico_header 13 GPIO_ACTIVE_HIGH>;	/* GP13 */
 };

--- a/boards/shields/rpi_pico_lcd/waveshare_pico_restouch_lcd_3_5.overlay
+++ b/boards/shields/rpi_pico_lcd/waveshare_pico_restouch_lcd_3_5.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,11 @@
 / {
 	chosen {
 		zephyr,display = &lcd_panel;
+	};
+
+	mipi_dbi: mipi-dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		write-only;
 	};
 
 	lcd_backlight_en: lcd-backlight-en {

--- a/boards/shields/waveshare_lcd/boards/waveshare_2_4_lcd/arduino_nano_r3.dtsi
+++ b/boards/shields/waveshare_lcd/boards/waveshare_2_4_lcd/arduino_nano_r3.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,17 +8,24 @@
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
-&lcd_backlight_en {
+&board_spi_lcd {
+	cs-gpios = <&arduino_nano_header 10 GPIO_ACTIVE_LOW>;		/* D10 */
+};
+
+&mipi_dbi {
 	status = "okay";
-	enable-gpios = <&arduino_nano_header 9 GPIO_ACTIVE_HIGH>;	/* D9 */
+	reset-gpios = <&arduino_nano_header 8 GPIO_ACTIVE_HIGH>;	/* D8 */
+	dc-gpios = <&arduino_nano_header 7 GPIO_ACTIVE_HIGH>;		/* D7 */
+	spi-dev = <&board_spi_lcd>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &lcd_panel {
 	status = "okay";
-	reset-gpios = <&arduino_nano_header 8 GPIO_ACTIVE_LOW>;		/* D8 */
-	cmd-data-gpios = <&arduino_nano_header 7 GPIO_ACTIVE_LOW>;	/* D7 */
 };
 
-&board_spi_lcd {
-	cs-gpios = <&arduino_nano_header 10 GPIO_ACTIVE_LOW>;		/* D10 */
+&lcd_backlight_en {
+	status = "okay";
+	enable-gpios = <&arduino_nano_header 9 GPIO_ACTIVE_HIGH>;	/* D9 */
 };

--- a/boards/shields/waveshare_lcd/boards/waveshare_2_4_lcd/cytron_maker_pi_rp2040.overlay
+++ b/boards/shields/waveshare_lcd/boards/waveshare_2_4_lcd/cytron_maker_pi_rp2040.overlay
@@ -1,22 +1,29 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "ili9341_240x320.dtsi"
 #include "ili9341_rgb565.dtsi"
 
-&lcd_backlight_en {
+&board_spi_lcd {
+	cs-gpios = <&grove_gpios 5 GPIO_ACTIVE_LOW>;		/* D5 */
+};
+
+&mipi_dbi {
 	status = "okay";
-	enable-gpios = <&grove_gpios 7 GPIO_ACTIVE_HIGH>;	/* D7 */
+	reset-gpios = <&grove_gpios 28 GPIO_ACTIVE_HIGH>;	/* D28 */
+	dc-gpios = <&grove_gpios 6 GPIO_ACTIVE_HIGH>;		/* D6 */
+	spi-dev = <&board_spi_lcd>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 };
 
 &lcd_panel {
 	status = "okay";
-	reset-gpios = <&grove_gpios 28 GPIO_ACTIVE_LOW>;	/* D28 */
-	cmd-data-gpios = <&grove_gpios 6 GPIO_ACTIVE_LOW>;	/* D6 */
 };
 
-&board_spi_lcd {
-	cs-gpios = <&grove_gpios 5 GPIO_ACTIVE_LOW>;		/* D5 */
+&lcd_backlight_en {
+	status = "okay";
+	enable-gpios = <&grove_gpios 7 GPIO_ACTIVE_HIGH>;	/* D7 */
 };

--- a/boards/shields/waveshare_lcd/boards/waveshare_2_4_lcd/ili9341_240x320.dtsi
+++ b/boards/shields/waveshare_lcd/boards/waveshare_2_4_lcd/ili9341_240x320.dtsi
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <freq.h>
 #include <zephyr/dt-bindings/display/ili9xxx.h>
 
-&board_spi_lcd {
+&mipi_dbi {
 	ili9341_240x320: ili9341@0 {
 		compatible = "ilitek,ili9341";
-		spi-max-frequency = <DT_FREQ_M(25)>;
+		mipi-max-frequency = <DT_FREQ_M(25)>;
 		reg = <0>;
 
 		status = "disabled";

--- a/boards/shields/waveshare_lcd/boards/waveshare_2_4_lcd/ili9341_320x240.dtsi
+++ b/boards/shields/waveshare_lcd/boards/waveshare_2_4_lcd/ili9341_320x240.dtsi
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <freq.h>
 #include <zephyr/dt-bindings/display/ili9xxx.h>
 
-&board_spi_lcd {
+&mipi_dbi {
 	ili9341_320x240: ili9341@0 {
 		compatible = "ilitek,ili9341";
-		spi-max-frequency = <DT_FREQ_M(25)>;
+		mipi-max-frequency = <DT_FREQ_M(25)>;
 		reg = <0>;
 
 		status = "disabled";

--- a/boards/shields/waveshare_lcd/waveshare_2_4_lcd.overlay
+++ b/boards/shields/waveshare_lcd/waveshare_2_4_lcd.overlay
@@ -1,11 +1,16 @@
 /*
- * Copyright (c) 2023 TiaC Systems
+ * Copyright (c) 2023-2024 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
 / {
 	chosen {
 		zephyr,display = &lcd_panel;
+	};
+
+	mipi_dbi: mipi-dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		write-only;
 	};
 
 	lcd_backlight_en: lcd-backlight-en {

--- a/doc/bridle/releases/release-notes-3.6.0.rst
+++ b/doc/bridle/releases/release-notes-3.6.0.rst
@@ -201,6 +201,9 @@ Change log
     * **Pico LCD 2** shield by Waveshare
     * **Pico ResTouch LCD 3.5** shield by Waveshare
 
+      *Currently not functional because of missing MIPI DBI device type C,
+      SPI with 16-bit support, on Zephyr upstream!*
+
   * *Waveshare LCD Modules*:
 
     * **2.4inch LCD Module** as shield by Waveshare
@@ -223,6 +226,7 @@ Take over the new build principles from Zephyr:
 
 :brd:`NOT YET, tbd.`
 
+* Use the new upstream *MIPI DBI API* for all *ILI9xxx* based displays.
 * tbd.
 * tbd.
 * tbd.


### PR DESCRIPTION
- use the new upstream *MIPI DBI API* for all *ILI9xxx* based displays
- fix Devicetree structures (missing pinctrl node references)
- "The PicoBoy" doesn't need to set OLED to inverted output