### PR TITLE
Reactivate the 16-bit shift register support on Waveshare Pico ResTouch LCD 3.5 shield

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -71,7 +71,7 @@ jobs:
           sudo apt-get install -y ninja-build doxygen mscgen graphviz
 
       - name: Restore PIP Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-doc-pip
@@ -142,7 +142,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doc
           path: workspace/build/doc

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/doc-remove.yml
+++ b/.github/workflows/doc-remove.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doc
           path: doc

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/qa-compliance.yml
+++ b/.github/workflows/qa-compliance.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 name: QA Compliance Check
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore PIP Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-doc-pip
@@ -101,7 +101,7 @@ jobs:
             -c origin/${BASE_REF}..
 
       - name: Upload compliance tests results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: compliance.xml
           path: workspace/bridle/compliance.xml

--- a/.github/workflows/qa-igt-slz.yml
+++ b/.github/workflows/qa-igt-slz.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -26,7 +26,7 @@ jobs:
           rm -rf "${{ github.workspace }}/workspace"
 
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: workspace/bridle
           submodules: recursive
@@ -85,14 +85,14 @@ jobs:
         continue-on-error: true
 
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: twister_report.xml
           path: workspace/twister-out/twister_report.xml
         continue-on-error: true
 
       - name: Convert integration test reports to annotations
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: twister-report (${{ matrix.board }})
           report_paths: "**/twister-out/twister_report.xml"

--- a/.github/workflows/qa-integration.yml
+++ b/.github/workflows/qa-integration.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -91,7 +91,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore PIP Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-qa-pip
@@ -134,13 +134,13 @@ jobs:
             --testsuite-root bridle/samples/waveshare_pico_environment_sensor
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: twister-samples.xml
           path: workspace/twister-out/twister.xml
 
       - name: Convert integration test reports to annotations
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: twister-report (samples)
           report_paths: "**/twister-out/twister.xml"
@@ -203,7 +203,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore PIP Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-qa-pip
@@ -254,13 +254,13 @@ jobs:
             --testsuite-root bridle/tests/shields/x_grove_testbed/dts_bindings
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: twister-shields.xml
           path: workspace/twister-out/twister.xml
 
       - name: Convert integration test reports to annotations
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: twister-report (shields)
           report_paths: "**/twister-out/twister.xml"
@@ -373,13 +373,13 @@ jobs:
             --tag can
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: twister-targets.xml
           path: workspace/twister-out/twister.xml
 
       - name: Convert integration test reports to annotations
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: twister-report (${{ matrix.board }})
           report_paths: "**/twister-out/twister.xml"

--- a/.github/workflows/qa-licenses.yml
+++ b/.github/workflows/qa-licenses.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 name: QA License Check
@@ -24,7 +24,7 @@ jobs:
           directory-to-scan: 'scan/'
 
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scancode
           path: ./artifacts

--- a/.github/workflows/qa-manifest.yml
+++ b/.github/workflows/qa-manifest.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: workspace/bridle
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 TiaC Systems
+# Copyright (c) 2021-2024 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 name: Mark Stale Issues and Pull Requests
@@ -18,15 +18,15 @@ jobs:
     if: github.repository == 'tiacsys/bridle'
 
     steps:
-    - uses: actions/stale@v6
-      with:
-        days-before-stale: 90
-        days-before-close: 30
-        exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'
-        stale-issue-label: 'Stale'
-        stale-issue-message: 'This issue has been marked as stale because it has been open (more than) 90 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 30 days. Note, that you can always re-open a closed issue at any time.'
-        exempt-pr-labels: 'Blocked,In progress'
-        stale-pr-label: 'Stale'
-        stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 90 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 30 days. Note, that you can always re-open a closed pull request at any time.'
-        operations-per-run: 400
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 90
+          days-before-close: 30
+          exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'
+          stale-issue-label: 'Stale'
+          stale-issue-message: 'This issue has been marked as stale because it has been open (more than) 90 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 30 days. Note, that you can always re-open a closed issue at any time.'
+          exempt-pr-labels: 'Blocked,In progress'
+          stale-pr-label: 'Stale'
+          stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 90 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 30 days. Note, that you can always re-open a closed pull request at any time.'
+          operations-per-run: 400
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/rpipico_r3.dtsi
+++ b/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/rpipico_r3.dtsi
@@ -44,10 +44,7 @@
 
 &lcd_panel {
 	status = "okay";
-	//spi2mcu-shift = <16>;	/* 16-bit shifted register data */
-	/* TODO: port to new MIPI DBI API. That needs a new MIPI DBI device
-	 * interface type on Zephyr upstream: Type C, SPI with command/data
-         * selected via GPIO pin --- BUT 16 write clocks per byte. */
+	spi2mcu-shift = <16>;	/* 16-bit shifted register data */
 };
 
 &lcd_backlight_en {

--- a/doc/bridle/releases/release-notes-3.6.0.rst
+++ b/doc/bridle/releases/release-notes-3.6.0.rst
@@ -201,9 +201,6 @@ Change log
     * **Pico LCD 2** shield by Waveshare
     * **Pico ResTouch LCD 3.5** shield by Waveshare
 
-      *Currently not functional because of missing MIPI DBI device type C,
-      SPI with 16-bit support, on Zephyr upstream!*
-
   * *Waveshare LCD Modules*:
 
     * **2.4inch LCD Module** as shield by Waveshare


### PR DESCRIPTION
With the introduction of the new MIPI DBI API on Zephyr upstream we lost this feature for a couple of weeks. Now, on upstream the [PR67089](https://github.com/zephyrproject-rtos/zephyr/pull/67089) was refreshed and the functionality is back again.