### PR TITLE
Bump devcontainer version to latest tagged version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"dockerfile": "Dockerfile",
 		// Specify version for Zephyr Container
 		// See https://github.com/zephyrproject-rtos/docker-image/releases
-		"args": { "ZEPHYR_TAG": "v0.26.5" }
+		"args": { "ZEPHYR_TAG": "v0.26.7" }
 	},
 	// Needed for USB devices in container
 	"privileged": true,

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -14,4 +14,4 @@ west bridle-export
 
 
 pip3 install --upgrade --requirement zephyr/scripts/requirements.txt
-pip3 install --upgrade --requirement bridle/scripts/requirements.txt
+pip3 install --upgrade --requirement $REPO_NAME/scripts/requirements.txt


### PR DESCRIPTION
This will bump the used container version for building to the latest tagged one. Also a small fix is included if the user clones the bridle repository in a folder with a name which is not "bridle".