### PR TITLE
Update Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -212,11 +212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708425171,
-        "narHash": "sha256-+KbQNk1RzW1Q5EvnB9q/B7H23NQoO3VLd/bDlTOrvyk=",
+        "lastModified": 1715759904,
+        "narHash": "sha256-NfYsuN7fKZqbpur36q5yznJ1d5b7IOpF2TffYwS2KQ0=",
         "owner": "irockasingranite",
         "repo": "bridle-python-deps",
-        "rev": "d779b4e36484adb65a814d1498efc369aac57d38",
+        "rev": "5f23ee874d13dd3e1948c7e13cac4eceac4664ef",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709569716,
-        "narHash": "sha256-iOR44RU4jQ+YPGrn+uQeYAp7Xo7Z/+gT+wXJoGxxLTY=",
+        "lastModified": 1715668745,
+        "narHash": "sha256-xp62OkRkbUDNUc6VSqH02jB0FbOS+MsfMb7wL1RJOfA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "617579a787259b9a6419492eaac670a5f7663917",
+        "rev": "9ddcaffecdf098822d944d4147dd8da30b4e6843",
         "type": "github"
       },
       "original": {
@@ -168,11 +168,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1709593159,
-        "narHash": "sha256-mPZaI2ctBNP78n5qTa5o+zzK54bN4gt9R7YyIfO7mgU=",
+        "lastModified": 1715798112,
+        "narHash": "sha256-jK8aZ2JnXd7vwEL4szowtKMqMXWY1079l5qi84kNV30=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "5ece746db4c561fdb9cd18575adc7a2a1a6026ed",
+        "rev": "688e2bd41f2e31313c822cf4bb84ac0e67292658",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     "zephyr": {
       "flake": false,
       "locked": {
-        "lastModified": 1715803783,
-        "narHash": "sha256-dLISveYYBC9+EV6PIUUMZSbStIzaTyoZrj0gJH0odo8=",
+        "lastModified": 1715846897,
+        "narHash": "sha256-bJM8hYZtjgpZ8VipLqHrkylAVvqtQRhF1pMslYzCQ8Q=",
         "owner": "tiacsys",
         "repo": "zephyr",
-        "rev": "3992364eb88dda0dc3af68b09cbe03de6d88756d",
+        "rev": "f58854e9f9097168e2a943a8e17d88e77920d632",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709345571,
-        "narHash": "sha256-2MzrVPi0GFFtWNqc7i7Vc5MYqUz31HKw8KSKDf6X3m0=",
+        "lastModified": 1712044799,
+        "narHash": "sha256-OHBz1mVLAzNY3OoB3Xqy5hMDgOODfAoas3aGph5y86g=",
         "owner": "adisbladis",
         "repo": "zephyr-nix",
-        "rev": "311d2ad38ca29fedecd3201d9b7fd81848d44895",
+        "rev": "6a007cf4effdd9092e8a8d103c643ee1e26f720e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -292,16 +292,16 @@
     "zephyr": {
       "flake": false,
       "locked": {
-        "lastModified": 1708734632,
-        "narHash": "sha256-iwEXEIA63JWSB6GcTNHHMZAEfMEwEfqcIWetF7VD2tU=",
+        "lastModified": 1715803783,
+        "narHash": "sha256-dLISveYYBC9+EV6PIUUMZSbStIzaTyoZrj0gJH0odo8=",
         "owner": "tiacsys",
         "repo": "zephyr",
-        "rev": "468eb56cf242eedba62006ee758700ee6148763f",
+        "rev": "3992364eb88dda0dc3af68b09cbe03de6d88756d",
         "type": "github"
       },
       "original": {
         "owner": "tiacsys",
-        "ref": "v3.6-branch",
+        "ref": "tiacsys/main",
         "repo": "zephyr",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -212,11 +212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715759904,
-        "narHash": "sha256-NfYsuN7fKZqbpur36q5yznJ1d5b7IOpF2TffYwS2KQ0=",
+        "lastModified": 1715835677,
+        "narHash": "sha256-5pyXTtynEh9pYhNUk3/EfxUbdBQA8txPY5B5JJZMmzA=",
         "owner": "irockasingranite",
         "repo": "bridle-python-deps",
-        "rev": "5f23ee874d13dd3e1948c7e13cac4eceac4664ef",
+        "rev": "b697244d6647fe2758df71fe7af7f5dbaeaf717f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       type = "github";
       owner = "tiacsys";
       repo = "zephyr";
-      ref = "v3.6-branch";
+      ref = "tiacsys/main";
       flake = false;
     };
 

--- a/python.nix
+++ b/python.nix
@@ -20,6 +20,7 @@ let
 
       # Extra python packages that aren't in nixpkgs
       inherit (python-deps)
+        bz
         doxmlparser
         pydebuggerconfig
         pyedbglib

--- a/python.nix
+++ b/python.nix
@@ -20,6 +20,7 @@ let
 
       # Extra python packages that aren't in nixpkgs
       inherit (python-deps)
+        doxmlparser
         pydebuggerconfig
         pyedbglib
         pykitinfo

--- a/west2nix.toml
+++ b/west2nix.toml
@@ -4,16 +4,16 @@ group-filter = ["-babblesim"]
 [[manifest.projects]]
 name = "ubxlib"
 url = "https://github.com/tiacsys/ubxlib"
-revision = "c564a1ac88e62117d88277e4e74513de50a95c45"
+revision = "775806f3feacc8e2816465e50550d74fd4e27ac9"
 path = "modules/lib/ubxlib"
 
 [manifest.projects.nix]
-hash = "sha256-Qx9S7l0q1d6vJbqxRgyplqFr+seH/QybHYs84EN2Jbo="
+hash = "sha256-E7b40VGy7qQ26eXRbSVqhIuJiDOWqJ6+oYqQmnbo7AM="
 
 [[manifest.projects]]
 name = "zephyr"
 url = "https://github.com/tiacsys/zephyr"
-revision = "6c93afc3d2572a8f3f4aed0c81d80176f6bbb2ff"
+revision = "3992364eb88dda0dc3af68b09cbe03de6d88756d"
 clone-depth = 5000
 west-commands = "scripts/west-commands.yml"
 
@@ -21,7 +21,7 @@ west-commands = "scripts/west-commands.yml"
 west-commands-path = "scripts/west_commands"
 
 [manifest.projects.nix]
-hash = "sha256-WsAK7oFvYPPU1zIxelnfARKj82XdtJt5ndKOTaXJZrY="
+hash = "sha256-s571cJA19QPkU/qki4QTw+uHZ2e9NyvYSEl3OrwZZMM="
 
 [[manifest.projects]]
 name = "canopennode"
@@ -56,12 +56,21 @@ hash = "sha256-oYpqLIbtKsNHQ9FQjhSM8Rvd/VM4M+ETO5hum2fZVq8="
 [[manifest.projects]]
 name = "tf-m-tests"
 url = "https://github.com/zephyrproject-rtos/tf-m-tests"
-revision = "08a3158f0623a4205608a52d880b17ae394e31d2"
+revision = "85f533a4aa5b4fe31247676a923db7453eb4429c"
 path = "modules/tee/tf-m/tf-m-tests"
 groups = ["optional"]
 
 [manifest.projects.nix]
-hash = "sha256-wALfatKKBeUh1rLWOIxRn2/Tm0XDh34cHUA5IFybbgc="
+hash = "sha256-WR/3UstEoAAxcf8XXpjBnpm1ksxfw7py2P6WjPQ0Irs="
+
+[[manifest.projects]]
+name = "acpica"
+url = "https://github.com/zephyrproject-rtos/acpica"
+revision = "da5f2721e1c7f188fe04aa50af76f4b94f3c3ea3"
+path = "modules/lib/acpica"
+
+[manifest.projects.nix]
+hash = "sha256-y2if6wP0Xm98iFwDkV0Ot1BIv6KhI1T3MaY5Ba0oCCs="
 
 [[manifest.projects]]
 name = "cmsis"
@@ -104,25 +113,24 @@ groups = ["hal"]
 hash = "sha256-H2C+3ASsC5O/mA+O5EJqfoJgx0BhSN0W3OhWNHVQxRU="
 
 [[manifest.projects]]
+name = "hal_ambiq"
+url = "https://github.com/zephyrproject-rtos/hal_ambiq"
+revision = "94dd874cd726ba8185a301e78337c5c39685123f"
+path = "modules/hal/ambiq"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-1YDU9LqO5XqMnUtLcYUS/VK0FnCe243QsO9683MpzB4="
+
+[[manifest.projects]]
 name = "hal_atmel"
 url = "https://github.com/zephyrproject-rtos/hal_atmel"
-revision = "aad79bf530b69b72712d18873df4120ad052d921"
+revision = "d6221e73d76a4a31d802e0657342fcbda77e21ae"
 path = "modules/hal/atmel"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-9mJjeX9l7orJvYXjW46YROTPvm389KKF3s1XYj7g+VM="
-
-[[manifest.projects]]
-name = "hal_espressif"
-url = "https://github.com/zephyrproject-rtos/hal_espressif"
-revision = "67fa60bdffca7ba8ed199aecfaa26f485f24878b"
-path = "modules/hal/espressif"
-west-commands = "west/west-commands.yml"
-groups = ["hal"]
-
-[manifest.projects.nix]
-hash = "sha256-RbR5+SK3Ijn9f/VQ8FzxVy/VYPcP22iVAaIjpaYvV0U="
+hash = "sha256-jciNzeOiYhlyYRAPgtg/gVjpF4pUyt7Zk+1rssoHrz0="
 
 [[manifest.projects]]
 name = "hal_gigadevice"
@@ -137,52 +145,62 @@ hash = "sha256-Cgcc+7tJy0ryQG4ynrlv7OmNe3OW2kMx1mStGROgA5o="
 [[manifest.projects]]
 name = "hal_infineon"
 url = "https://github.com/zephyrproject-rtos/hal_infineon"
-revision = "69c883d3bd9fac8a18dd8384624b8c472a68d06f"
+revision = "b1a47231e8671c882c5f055f9f10c32b18133d08"
 path = "modules/hal/infineon"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-v6Vvw/h007KEznd1/2tbHg1P06yXX7flPn9mLaWm0CU="
+hash = "sha256-gt45U8NZ7SGBN2L9RxMNNsw7HoIa8dxP1wGNX3mk8g4="
+
+[[manifest.projects]]
+name = "hal_intel"
+url = "https://github.com/zephyrproject-rtos/hal_intel"
+revision = "7b4c25669f1513b0d6d6ee78ee42340d91958884"
+path = "modules/hal/intel"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-h2r4jKmqVaGoTxfJKQ+S2Zegg/MAfCiIBrpBHtVnsrA="
 
 [[manifest.projects]]
 name = "hal_microchip"
 url = "https://github.com/zephyrproject-rtos/hal_microchip"
-revision = "5d079f1683a00b801373bbbbf5d181d4e33b30d5"
+revision = "68575aa28cd33c68b3b8d66f510d15746c57fdb5"
 path = "modules/hal/microchip"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-CJdNHsowN9WsKSHekypUdeJvOJ19/0PHZU874CXVaoU="
+hash = "sha256-Q2mJFu9PM7vWB+H9rUVkiUnId5mDDs6ZKyQJ2kF33tQ="
 
 [[manifest.projects]]
 name = "hal_nordic"
 url = "https://github.com/zephyrproject-rtos/hal_nordic"
-revision = "dce8519f7da37b0a745237679fd3f88250b495ff"
+revision = "a3aacc7e43dec644a9ddfee4aa578a4f8ff54610"
 path = "modules/hal/nordic"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-cdZIYWc3uCeseGkJoEFxE2iZlfSnlpaVhNUo1g0+4vM="
+hash = "sha256-Pnu0yp+LYz7WTbvO+bXg1PaFxF/zkoNJt250uu8iEkw="
 
 [[manifest.projects]]
 name = "hal_nuvoton"
 url = "https://github.com/zephyrproject-rtos/hal_nuvoton"
-revision = "68a91bb343ff47e40dbd9189a7d6e3ee801a7135"
+revision = "ab342e6915bf7bff2203a20985754f6dbdb5343d"
 path = "modules/hal/nuvoton"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-oilM3sRalL9ruIIukM3G/Vg6dI/Ahwma3kUHf7x/6wE="
+hash = "sha256-LYbv5A7IGICZ5/uDZe8cyCMpV1HiitBXbZ3QbgHku0s="
 
 [[manifest.projects]]
 name = "hal_nxp"
 url = "https://github.com/zephyrproject-rtos/hal_nxp"
-revision = "d45b14c198d778658b7853b48378d2e132a6c4be"
+revision = "8c354a918c1272b40ad9b4ffecac1d89125efbe6"
 path = "modules/hal/nxp"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-fHnZ775PZ7jwpNmrW8n/+j0vE2AnV8OsX4lm0glr1Fc="
+hash = "sha256-JJ44H2MDADrgTGwnnkaxoNQnVsVZJ6zimbB+2ZuhRt4="
 
 [[manifest.projects]]
 name = "hal_openisa"
@@ -197,22 +215,22 @@ hash = "sha256-krI/9sr57ZjerDKb9lQvIOD+q6vfiXqRGqV7cbW9Bqs="
 [[manifest.projects]]
 name = "hal_quicklogic"
 url = "https://github.com/zephyrproject-rtos/hal_quicklogic"
-revision = "b3a66fe6d04d87fd1533a5c8de51d0599fcd08d0"
+revision = "bad894440fe72c814864798c8e3a76d13edffb6c"
 path = "modules/hal/quicklogic"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-XpPROaiZN0KRxQCtEOYaXSEBtxAo+atnH1ytOMXpYUI="
+hash = "sha256-EFeySS+Kz7RecJ7it5CVAdP0y9m2gCCGl0Pu6l21+TQ="
 
 [[manifest.projects]]
 name = "hal_renesas"
 url = "https://github.com/zephyrproject-rtos/hal_renesas"
-revision = "0b1f2fdb99d6386f125a8dba72083e3c56aecc2b"
+revision = "e3560c79db1a002014f061c611cd84a99e4f33de"
 path = "modules/hal/renesas"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-BPvUTX3FhSz8yKOMDjOLGqGisKV69AMwlYxwJ622anY="
+hash = "sha256-tQePVx8sx0xVWBVl7uxlXbot+64K/vlD3ThM6c3xYns="
 
 [[manifest.projects]]
 name = "hal_rpi_pico"
@@ -227,32 +245,32 @@ hash = "sha256-qv0GPlBQ0np8a0obi5pt6LyxKiTIqWEhoG7vI4jLAwc="
 [[manifest.projects]]
 name = "hal_silabs"
 url = "https://github.com/zephyrproject-rtos/hal_silabs"
-revision = "b11b29167f3f9a0fd0c34a8eeeb36b0c1d218917"
+revision = "0c39ee28be31c59a98ed490c3811f68caa1fcbd3"
 path = "modules/hal/silabs"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-AqYwRoKW1FJFJYc/J3KK84lQpy6LxFOPUXDXrDIYUZs="
+hash = "sha256-rRDkGRR115FpLOpUUIwVcFVCeJqBC5PDtvBFpWKHa3M="
 
 [[manifest.projects]]
 name = "hal_st"
 url = "https://github.com/zephyrproject-rtos/hal_st"
-revision = "0643d20ae85b32c658ad11036f7c964a860ddefe"
+revision = "b77157f6bc4395e398d90ab02a7d2cbc01ab2ce7"
 path = "modules/hal/st"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-b/uaXxebfasYCS1rEnEqEoHwH7CYywg6HxaDntJ9mKg="
+hash = "sha256-zjRgI7ZzDcztvChaLohl3rXAaKTMdW9A2G306RoC2Xc="
 
 [[manifest.projects]]
 name = "hal_stm32"
 url = "https://github.com/zephyrproject-rtos/hal_stm32"
-revision = "60c9634f61c697e1c310ec648d33529712806069"
+revision = "ed93098718d5c727d2fac5ef27023a2a14763e32"
 path = "modules/hal/stm32"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-uvkOKfVMfYql0YaGLOJQQboqiXKEDo19lV6x23XyUYE="
+hash = "sha256-VTjLW3SQvoZn16kC/i/LmMQdzwjlY7hFIbMqzUtmTx8="
 
 [[manifest.projects]]
 name = "hal_telink"
@@ -277,12 +295,12 @@ hash = "sha256-NaXcMhV3GG+BexuQx3S4vtEchLgKasMlo1NJ+V56JBk="
 [[manifest.projects]]
 name = "hal_xtensa"
 url = "https://github.com/zephyrproject-rtos/hal_xtensa"
-revision = "08325d6fb7190a105f5382d35e64ed2812c57cf4"
+revision = "a2d658525b16c57bea8dd565f5bd5167e4b9f1ee"
 path = "modules/hal/xtensa"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-9vihVhCzVGG+CYrN9pNtBUMM3WfFwrgI8brq0zGILBI="
+hash = "sha256-1EtwoP89uqMo6wpoB2RH4h6Qvj3U8yX8K0tCMyM+zeo="
 
 [[manifest.projects]]
 name = "libmetal"
@@ -316,39 +334,39 @@ hash = "sha256-r0YCwuH5RQill5xtjPUV5NUsKqs3U0k8I2W5knKXVb8="
 [[manifest.projects]]
 name = "loramac-node"
 url = "https://github.com/zephyrproject-rtos/loramac-node"
-revision = "842413c5fb98707eb5f26e619e8e792453877897"
+revision = "fb00b383072518c918e2258b0916c996f2d4eebe"
 path = "modules/lib/loramac-node"
 
 [manifest.projects.nix]
-hash = "sha256-5/qUGojHZVNoT7SOsTGNA/pFCuOGrPzibv0MoJdq/rk="
+hash = "sha256-mzvH8wh+si6q0QCoPl/mAm0QI3PkXGY3uaOMkimQtqg="
 
 [[manifest.projects]]
 name = "lvgl"
 url = "https://github.com/zephyrproject-rtos/lvgl"
-revision = "2b76c641749725ac90c6ac7959ca7718804cf356"
+revision = "2b498e6f36d6b82ae1da12c8b7742e318624ecf5"
 path = "modules/lib/gui/lvgl"
 
 [manifest.projects.nix]
-hash = "sha256-X3DOhGCMFb03eubcc5VcHRPt1RKWzyviaTUh1HXzGDc="
+hash = "sha256-esrGS2Mz7RnT91O/wvMwxhtRemf7aq2iNAApCNonkCU="
 
 [[manifest.projects]]
 name = "mbedtls"
 url = "https://github.com/zephyrproject-rtos/mbedtls"
-revision = "6ec4abdcda78dfc47315af568f93e5ad4398dea0"
+revision = "3217c450180fd5e817601c6f479116de69e57461"
 path = "modules/crypto/mbedtls"
 groups = ["crypto"]
 
 [manifest.projects.nix]
-hash = "sha256-r4CcM/VuG9JJavT+YOn5EEFWTvEDnjPAy6H+UkIeZ6s="
+hash = "sha256-Q0h+t8lNE07sPlfjjupWkArdTt1wV7IgU4u9FGsZzjk="
 
 [[manifest.projects]]
 name = "mcuboot"
 url = "https://github.com/zephyrproject-rtos/mcuboot"
-revision = "a4eda30f5b0cfd0cf15512be9dcd559239dbfc91"
+revision = "d4394c2f9b76e0a7b758441cea3a8ceb896f66c8"
 path = "bootloader/mcuboot"
 
 [manifest.projects.nix]
-hash = "sha256-m9sy2QxHIkXF7vX1FNq+CjOMzchbEeQmcTnaPijpl5A="
+hash = "sha256-ARgDJ5wg+SkXN71kSBytwEk2SQwg1MT0M+zU4LZhOns="
 
 [[manifest.projects]]
 name = "mipi-sys-t"
@@ -363,12 +381,12 @@ hash = "sha256-O5BkXoaCj3xxRsaoarDcCSxhovhH0ihvmY0COy6BQK0="
 [[manifest.projects]]
 name = "net-tools"
 url = "https://github.com/zephyrproject-rtos/net-tools"
-revision = "3a677d355cc7f73e444801a6280d0ccec80a1957"
+revision = "cd2eb1858a1570b49241e18fc1e1cd849a450af2"
 path = "tools/net-tools"
 groups = ["tools"]
 
 [manifest.projects.nix]
-hash = "sha256-YlaszC8BNXCzSGAusiYhEzzRs55gnWykN/3zb0MGA7w="
+hash = "sha256-EkisIg3DJBgULxyIVB7P1muHVlZCqh50KbbV/dfCnlY="
 
 [[manifest.projects]]
 name = "open-amp"
@@ -382,11 +400,11 @@ hash = "sha256-7yae0X7zqDPA4CUfGU3LgNBh7qyKGIPLUv6dn/d65Fg="
 [[manifest.projects]]
 name = "openthread"
 url = "https://github.com/zephyrproject-rtos/openthread"
-revision = "7761b81d23b10b3d5ee21b8504c67535cde10896"
+revision = "49c59ec519cc8b49dd58978d1bc80b7ae7ba88d0"
 path = "modules/lib/openthread"
 
 [manifest.projects.nix]
-hash = "sha256-/GKaDl/mlBwsuRq0RNnV2vzXRC6pfz1CwHPm9RfyzwU="
+hash = "sha256-/t8aoOdinVcXEmsKmErr7dXWHO6v370/ABulua3+ATc="
 
 [[manifest.projects]]
 name = "picolibc"
@@ -400,32 +418,32 @@ hash = "sha256-5W/+vorhOP/MD19JYzHJfZTkWMM7sKUQqzTDA/7rxZs="
 [[manifest.projects]]
 name = "segger"
 url = "https://github.com/zephyrproject-rtos/segger"
-revision = "9d0191285956cef43daf411edc2f1a7788346def"
+revision = "b011c45b585e097d95d9cf93edf4f2e01588d3cd"
 path = "modules/debug/segger"
 groups = ["debug"]
 
 [manifest.projects.nix]
-hash = "sha256-9nt0z674ubxxvIANPMf82Qf7KsOwR3Hg8wYAK5r/i4c="
+hash = "sha256-otxrP9Z4fUlJvdQ52jIXz9Bb6Fy3mr/jEFx9lhz0QlE="
 
 [[manifest.projects]]
 name = "tinycrypt"
 url = "https://github.com/zephyrproject-rtos/tinycrypt"
-revision = "3e9a49d2672ec01435ffbf0d788db6d95ef28de0"
+revision = "1012a3ebee18c15ede5efc8332ee2fc37817670f"
 path = "modules/crypto/tinycrypt"
 groups = ["crypto"]
 
 [manifest.projects.nix]
-hash = "sha256-5gtZbZNx+D/EUkyYk7rPtcxBZaNs4IFGTP/7IXzCoqU="
+hash = "sha256-JQmkN+ircGU5Ald1+Q4lysuxhZLg2mJpNQ92+agMoCQ="
 
 [[manifest.projects]]
 name = "trusted-firmware-m"
 url = "https://github.com/zephyrproject-rtos/trusted-firmware-m"
-revision = "0b898c9b72171b0a260c0bb64a92ea4713f9e931"
+revision = "785d87492490069b62170159fcf21c385f90f4eb"
 path = "modules/tee/tf-m/trusted-firmware-m"
 groups = ["tee"]
 
 [manifest.projects.nix]
-hash = "sha256-oVDl4uE4fPg98HjjQFFl/kNH90w7oulIHCB/84voOYQ="
+hash = "sha256-QATFZBBWeJeyF5hyOU9fsd5LQLueeJgDpeI7sj7xFf4="
 
 [[manifest.projects]]
 name = "trusted-firmware-a"


### PR DESCRIPTION
This PR brings the Bridle Nix flake in-sync with current bridle main.

In particular:

* The `zephyr` input now points towards `tiacsys/main`. When new release branches are created, their version of the flake should point toward the relevant zephyr release branch.
* The `west2nix.toml` manifest is updated to reflect a west workspace as fetched on 2024-05-16.*
* `doxmlparser` is added to the available python packages since bridle docs now require it.
* `bz` is added to the available python packages since zephyr tests now require it.
* The flake input locks are updated as of 2024-05-16.

\* It seems the `hal_espressif` zephyr module is currently subtly broken: At least one of its submodules is dangling and isn't/can't be fetched. This failure seems to be invisible to `west`, but `west2nix` notices that it can't prefetch the module correctly. Due to this, `espressif-hal` is manually excised from the generated `west2nix.toml` manifest for now, and is unavailable to nix builds.