### PR TITLE
Separate Bridle version header from zephyr header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,18 +8,17 @@ include(bridle/boards_extensions)
 
 # Generate our version header and inject into all builds.
 add_custom_command(
-  OUTPUT ${PROJECT_BINARY_DIR}/include/generated/version_bridle.h
+  OUTPUT ${PROJECT_BINARY_DIR}/include/generated/bridle/version.h
   COMMAND ${CMAKE_COMMAND}
     -DZEPHYR_BASE=${ZEPHYR_BASE}
     -DBRIDLE_BASE=${BRIDLE_BASE}
-    -DOUT_DIR=${PROJECT_BINARY_DIR}/include/generated
-    -DOUT_FILE=version_bridle.h
-    -DEXT_FILE=version.h
+    -DOUT_DIR=${PROJECT_BINARY_DIR}/include/generated/bridle
+    -DOUT_FILE=version.h
     -P ${BRIDLE_BASE}/cmake/gen_version_h.cmake
   DEPENDS ${BRIDLE_BASE}/VERSION ${git_dependency}
 )
 add_custom_target(version_bridle_h
-  DEPENDS ${PROJECT_BINARY_DIR}/include/generated/version_bridle.h)
+  DEPENDS ${PROJECT_BINARY_DIR}/include/generated/bridle/version.h)
 add_dependencies(version_bridle_h version_h)
 add_dependencies(zephyr_interface version_bridle_h)
 

--- a/cmake/gen_version_h.cmake
+++ b/cmake/gen_version_h.cmake
@@ -29,4 +29,3 @@ endif()
 
 include(${BRIDLE_BASE}/cmake/modules/bridle/version.cmake)
 configure_file(${BRIDLE_BASE}/version.h.in ${OUT_DIR}/${OUT_FILE})
-file(APPEND ${OUT_DIR}/${EXT_FILE} "\n#include \"${OUT_FILE}\"\n")

--- a/doc/bridle/releases/release-notes-3.7.0.rst
+++ b/doc/bridle/releases/release-notes-3.7.0.rst
@@ -201,6 +201,7 @@ Issue Related Items
 
 These GitHub issues were addressed since project bootstrapping:
 
+* :github:`227` - [BUG] Unable to build any application referencing bridle version information
 * :github:`222` - [BUG] unsatisfied dependencies by static Kconfig elements
 * :github:`217` - [FCR] Convert board ``arduino_zero`` to board extension
 * :github:`216` - [FCR] Convert all SOCs to new HWMv2

--- a/lib/bridle/version.c
+++ b/lib/bridle/version.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/types.h>
-#include "version.h" /* generated at compile time */
+#include "bridle/version.h" /* generated at compile time */
 
 /**
  * @brief Return the Bridle version of the present build

--- a/subsys/shell/modules/bridle_service.c
+++ b/subsys/shell/modules/bridle_service.c
@@ -4,7 +4,8 @@
  */
 
 #include <bridle/core.h>
-#include "version.h" /* generated at compile time */
+#include "zephyr/version.h" /* generated at compile time */
+#include "bridle/version.h" /* generated at compile time */
 
 #include <zephyr/shell/shell.h>
 

--- a/tests/bridle/common/src/main.c
+++ b/tests/bridle/common/src/main.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/ztest.h>
 #include <bridle/core_version.h>
-#include "version.h"
+#include "bridle/version.h"
 
 /**
  * @defgroup bridle_common_tests Common Tests


### PR DESCRIPTION
Fixes #227.

This PR moves bridle version information into a separate header file, namespaced in the include path similarly to the Zephyr version header.