### PR TITLE
Repair GH pipeline: QA integration tests for samples is broken

### DIFF
--- a/.github/workflows/qa-integration.yml
+++ b/.github/workflows/qa-integration.yml
@@ -125,16 +125,14 @@ jobs:
         working-directory: workspace
         run: |
           west twister --verbose --jobs 6 \
-            --retry-failed 5 --retry-interval 60 \
             --outdir twister-out --no-clean --inline-logs \
             --enable-size-report --platform-reports \
-            --integration \
-            --testsuite-root bridle/samples/button \
-            --testsuite-root bridle/samples/buzzer \
-            --testsuite-root bridle/samples/helloshell \
-            --testsuite-root bridle/samples/ubx_gnss \
-            --testsuite-root bridle/samples/waveshare_pico_10dof_imu_sensor \
-            --testsuite-root bridle/samples/waveshare_pico_environment_sensor
+            --alt-config-root bridle/zephyr/alt-config \
+            --integration --no-detailed-test-id \
+            --testsuite-root bridle/samples \
+            --testsuite-root zephyr/samples \
+            --tag bridle \
+            --tag zephyr
 
       - name: Upload integration test results
         uses: actions/upload-artifact@v4
@@ -250,7 +248,6 @@ jobs:
           # --testsuite-root bridle/tests/shields/grove_led/dts_bindings \
           #
           west twister --verbose --jobs 6 \
-            --retry-failed 5 --retry-interval 60 \
             --outdir twister-out --no-clean --inline-logs \
             --enable-size-report --platform-reports \
             --integration --cmake-only \

--- a/samples/button/sample.yaml
+++ b/samples/button/sample.yaml
@@ -2,7 +2,9 @@ sample:
   description: Button sample, one of the simplest Zephyr application
   name: button
 common:
-  tags: introduction
+  tags:
+    - bridle
+    - introduction
   build_only: true
   platform_allow: nucleo_f413zh
   integration_platforms:

--- a/samples/buzzer/sample.yaml
+++ b/samples/buzzer/sample.yaml
@@ -1,14 +1,17 @@
 sample:
-  name: Buzzer using PWM
+  description: Buzzer using PWM
+  name: buzzer
+common:
+  tags:
+    - bridle
+    - drivers
+    - pwm
+  integration_platforms:
+    - cytron_maker_nano_rp2040
+    - cytron_maker_pi_rp2040
+    - picoboy
 tests:
   bridle.sample.buzzer:
-    tags:
-      - drivers
-      - pwm
     depends_on: pwm
     harness: buzzer
     filter: dt_alias_exists("pwm-buzzer0") and dt_compat_enabled("pwm-buzzers")
-    integration_platforms:
-      - cytron_maker_nano_rp2040
-      - cytron_maker_pi_rp2040
-      - picoboy

--- a/samples/helloshell/boards/qemu_cortex_m0.conf
+++ b/samples/helloshell/boards/qemu_cortex_m0.conf
@@ -4,5 +4,5 @@
 # disable components to avoid RAM overflow on BSS allocation
 CONFIG_FLASH=n
 CONFIG_FLASH_SHELL=n
-CONFIG_SENSOR_INFO=n
+CONFIG_SENSOR_SHELL=n
 CONFIG_SHELL_MINIMAL=y

--- a/samples/helloshell/sample.yaml
+++ b/samples/helloshell/sample.yaml
@@ -4,6 +4,7 @@ sample:
   name: hello shell
 common:
   tags:
+    - bridle
     - xip
     - kernel
     - introduction
@@ -21,7 +22,7 @@ common:
     - qemu_x86/atom/virt
     - qemu_x86/atom/xip
     # Qemu issue: - qemu_x86_lakemont
-    - qemu_x86_tiny
+    # Qemu issue: - qemu_x86_tiny
     - qemu_x86_64
     - qemu_x86_64/atom/nokpti
     - qemu_cortex_r5
@@ -83,7 +84,7 @@ common:
     - waveshare_rp2040_plus@16mb
     - waveshare_rp2040_geek
 tests:
-  bridle.samples.helloshell.commands:
+  bridle.sample.helloshell.commands:
     filter: CONFIG_QEMU_TARGET and CONFIG_SERIAL and
             (dt_chosen_enabled("zephyr,shell-uart") or
              CONFIG_XTENSA_SIM_CONSOLE)
@@ -91,7 +92,7 @@ tests:
       - CMAKE_BUILD_TYPE=ZRelease
     harness: pytest
     timeout: 300
-  bridle.samples.helloshell.sayhello:
+  bridle.sample.helloshell.sayhello:
     filter: CONFIG_QEMU_TARGET and CONFIG_CONSOLE and
             (dt_chosen_enabled("zephyr,console") or
              CONFIG_XTENSA_SIM_CONSOLE)
@@ -101,7 +102,7 @@ tests:
       type: one_line
       regex:
         - "Hello World! I'm THE SHELL from (.*)"
-  bridle.samples.helloshell.debug:
+  bridle.sample.helloshell.debug:
     build_only: true
     build_on_all: true
     extra_args: CMAKE_BUILD_TYPE=ZDebug

--- a/samples/ubx_gnss/sample.yaml
+++ b/samples/ubx_gnss/sample.yaml
@@ -3,7 +3,9 @@ sample:
     into a Zephyr application
   name: ubxlib gnss
 common:
-  tags: ubxlib
+  tags:
+    - bridle
+    - ubxlib
   integration_platforms:
     - mimxrt1010_evk
     - mimxrt1060_evk
@@ -16,11 +18,11 @@ common:
     - nucleo_f767zi
     - nucleo_l496zg
 tests:
-  bridle.samples.ubx_gnss.release:
+  bridle.sample.ubx_gnss.release:
     build_only: true
     build_on_all: true
     extra_args: CMAKE_BUILD_TYPE=ZRelease
-  bridle.samples.ubx_gnss.debug:
+  bridle.sample.ubx_gnss.debug:
     build_only: true
     build_on_all: true
     extra_args: CMAKE_BUILD_TYPE=ZDebug

--- a/samples/waveshare_pico_10dof_imu_sensor/sample.yaml
+++ b/samples/waveshare_pico_10dof_imu_sensor/sample.yaml
@@ -2,16 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 sample:
-  name: Waveshare Pico 10-DOF IMU Sensor Sample
+  description: Waveshare Pico 10-DOF IMU Sensor Sample
+  name: waveshare pico 10dof imu sensor
+common:
+  tags:
+    - bridle
+    - sensors
+    - lps22hb
+    - mpu9250
+  depends_on:
+    - pico_i2c
+    - pico_gpio
 tests:
   bridle.sample.waveshare_pico_10dof_imu_sensor_r2:
-    tags:
-      - sensors
-      - lps22hb
-      - mpu9250
-    depends_on:
-      - pico_i2c
-      - pico_gpio
     extra_args: SHIELD=waveshare_pico_10dof_imu_sensor_r2
     integration_platforms:
       - rpi_pico
@@ -20,13 +23,6 @@ tests:
       - waveshare_rp2040_plus
       - waveshare_rp2040_plus@16mb
   bridle.sample.waveshare_pico_10dof_imu_sensor_r1:
-    tags:
-      - sensors
-      - lps22hb
-      - mpu9250
-    depends_on:
-      - pico_i2c
-      - pico_gpio
     extra_args: SHIELD=waveshare_pico_10dof_imu_sensor_r1
     integration_platforms:
       - rpi_pico

--- a/samples/waveshare_pico_environment_sensor/sample.yaml
+++ b/samples/waveshare_pico_environment_sensor/sample.yaml
@@ -2,17 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 sample:
-  name: Waveshare Pico Environment Sensor Sample
+  description: Waveshare Pico Environment Sensor Sample
+  name: waveshare pico environment sensor
+common:
+  tags:
+    - bridle
+    - sensors
+    - bme280
+    - sgp40
+    - mpu9250  # FIXME: icm20948
+  depends_on:
+    - pico_i2c
+    - pico_gpio
 tests:
   bridle.sample.waveshare_pico_environment_sensor:
-    tags:
-      - sensors
-      - bme280
-      - sgp40
-      - mpu9250  # FIXME: icm20948
-    depends_on:
-      - pico_i2c
-      - pico_gpio
     extra_args: SHIELD=waveshare_pico_environment_sensor
     integration_platforms:
       - rpi_pico

--- a/zephyr/alt-config/drivers/display/sample.yaml
+++ b/zephyr/alt-config/drivers/display/sample.yaml
@@ -1,0 +1,54 @@
+sample:
+  name: Display Bit Order and Orientation
+common:
+  tags:
+    - zephyr
+    - shield
+    - drivers
+    - display
+  depends_on: spi
+  harness: display
+  build_only: true
+tests:
+  #
+  # shield: Waveshare Pico LCD 1.14
+  #
+  sample.drivers.display.waveshare_pico_lcd_1_14:
+    extra_args:
+      SHIELD=waveshare_pico_lcd_1_14
+    integration_platforms:
+      - rpi_pico
+      - rpi_pico/rp2040/w
+      - waveshare_rp2040_plus
+      - waveshare_rp2040_plus@16mb
+  #
+  # shield: Waveshare Pico LCD 2
+  #
+  sample.drivers.display.waveshare_pico_lcd_2:
+    extra_args:
+      SHIELD=waveshare_pico_lcd_2
+    integration_platforms:
+      - rpi_pico
+      - rpi_pico/rp2040/w
+      - waveshare_rp2040_plus
+      - waveshare_rp2040_plus@16mb
+  #
+  # shield: Waveshare Pico ResTouch LCD 3.5
+  #
+  sample.drivers.display.waveshare_pico_restouch_lcd_3_5:
+    extra_args:
+      SHIELD=waveshare_pico_restouch_lcd_3_5
+    integration_platforms:
+      - rpi_pico
+      - rpi_pico/rp2040/w
+      - waveshare_rp2040_plus
+      - waveshare_rp2040_plus@16mb
+  #
+  # shield: Waveshare 2.4 LCD
+  #
+  sample.drivers.display.waveshare_2_4_lcd:
+    extra_args:
+      SHIELD=waveshare_2_4_lcd
+    integration_platforms:
+      - cytron_maker_nano_rp2040
+      - cytron_maker_pi_rp2040

--- a/zephyr/alt-config/subsys/input/input_dump/sample.yaml
+++ b/zephyr/alt-config/subsys/input/input_dump/sample.yaml
@@ -1,0 +1,33 @@
+sample:
+  name: Input Dump
+common:
+  tags:
+    - zephyr
+    - shield
+    - input
+  build_only: true
+  depends_on: pico_gpio
+  harness: input
+tests:
+  #
+  # shield: Waveshare Pico LCD 1.14
+  #
+  sample.input.input_dump.waveshare_pico_lcd_1_14:
+    extra_args:
+      SHIELD=waveshare_pico_lcd_1_14
+    integration_platforms:
+      - rpi_pico
+      - rpi_pico/rp2040/w
+      - waveshare_rp2040_plus
+      - waveshare_rp2040_plus@16mb
+  #
+  # shield: Waveshare Pico LCD 2
+  #
+  sample.input.input_dump.waveshare_pico_lcd_2:
+    extra_args:
+      SHIELD=waveshare_pico_lcd_2
+    integration_platforms:
+      - rpi_pico
+      - rpi_pico/rp2040/w
+      - waveshare_rp2040_plus
+      - waveshare_rp2040_plus@16mb


### PR DESCRIPTION
### Restructuring QA integration tests for samples

In addition to Bridle's own examples, it should also be possible to build specific Zephyr upstream examples with an alternative configuration base with the Bridle-owned specifications. For this purpose, the new tags `zephyr` and `bridle` must be introduced and respected. For the GitHub workflows, this makes the explicit naming of individual test roots unnecessary. The selection is made exclusively via the newly introduced tags.

### Avoid RAM overflow on `qemu_cortex_m0`

Since Zephyr upstream PR 74435, the sensor shell commands rely on a complete integration of the sensor ASYNC API incl. RTIO subsystem with a thread pool for a dedicated RTIO work queue. This exceeds the 16KB RAM of the Cortex M0 emulator by far. The only option available at the moment is to disable the sensor shell commands.

### Protect supported display shields

In preparation to PR #238, #243 and #245 the GH pipeline have to catch all currently display shields by simple builds as integration tests.