### PR TITLE
chore: bump devcontainer version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"dockerfile": "Dockerfile",
 		// Specify version for Zephyr Container
 		// See https://github.com/zephyrproject-rtos/docker-image/releases
-		"args": { "ZEPHYR_TAG": "v0.26.13" }
+		"args": { "ZEPHYR_TAG": "v0.27.4" }
 	},
 	// Needed for USB devices in container
 	"privileged": true,


### PR DESCRIPTION
Tested by building "zephyr/samples/basic/blinky" for some boards.