### PR TITLE
drivers: mipi-dbi-spi: use string for xfr-min-bits property

### DIFF
--- a/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/rpipico_r3.dtsi
+++ b/boards/shields/rpi_pico_lcd/boards/waveshare_pico_restouch_lcd_3_5/rpipico_r3.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 TiaC Systems
+ * Copyright (c) 2023-2025 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@
 
 &mipi_dbi {
 	status = "okay";
-	xfr-min-bits = <MIPI_DBI_SPI_XFR_16BIT>;  /* 16-bit shifted xfr */
+	xfr-min-bits = "MIPI_DBI_SPI_XFR_16BIT";  /* 16-bit shifted xfr */
 	reset-gpios = <&rpipico_header 15 GPIO_ACTIVE_LOW>;	/* GP15 */
 	dc-gpios = <&rpipico_header 8 GPIO_ACTIVE_HIGH>;	/* GP8 */
 	spi-dev = <&rpipico_spi_lcd>;

--- a/snippets/tstdrv-bldall-display-adj/tstdrv-bldall-display-adj.overlay
+++ b/snippets/tstdrv-bldall-display-adj/tstdrv-bldall-display-adj.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 TiaC Systems
+ * Copyright (c) 2024-2025 TiaC Systems
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -216,7 +216,7 @@
 		dc-gpios = <&test_gpio_adj 0 0>;
 		spi-dev = <&test_spi_adj>;
 
-		xfr-min-bits = <MIPI_DBI_SPI_XFR_8BIT>;
+		xfr-min-bits = "MIPI_DBI_SPI_XFR_8BIT";
 
 		test_mipi_dbi_ili9488: ili9488@a {
 			compatible = "ilitek,ili9488";
@@ -241,7 +241,7 @@
 		dc-gpios = <&test_gpio_adj 0 0>;
 		spi-dev = <&test_spi_adj>;
 
-		xfr-min-bits = <MIPI_DBI_SPI_XFR_16BIT>;
+		xfr-min-bits = "MIPI_DBI_SPI_XFR_16BIT";
 		write-only;
 
 		test_mipi_dbi_xfr_16bit_ili9488: ili9488@14 {


### PR DESCRIPTION
Use a string for the xfr-min-bits property over an integer value, as this significantly improves the readability of the MIPI DBI SPI device binding.

Related to: zephyrproject-rtos/zephyr#83565