### PR TITLE
samples: button: additional board setups

### DIFF
--- a/samples/button/boards/cytron_maker_nano_rp2040.overlay
+++ b/samples/button/boards/cytron_maker_nano_rp2040.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dis_pwm_leds.dtsi"
+#include "ena_gpio_leds.dtsi"

--- a/samples/button/boards/cytron_maker_pi_rp2040.overlay
+++ b/samples/button/boards/cytron_maker_pi_rp2040.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dis_pwm_leds.dtsi"
+#include "ena_gpio_leds.dtsi"

--- a/samples/button/boards/dis_pwm_leds.dtsi
+++ b/samples/button/boards/dis_pwm_leds.dtsi
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pwm_leds {
+	status = "disabled";
+};

--- a/samples/button/boards/ena_gpio_leds.dtsi
+++ b/samples/button/boards/ena_gpio_leds.dtsi
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gpio_leds {
+	status = "okay";
+};

--- a/samples/button/boards/picoboy_rp2040.overlay
+++ b/samples/button/boards/picoboy_rp2040.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dis_pwm_leds.dtsi"
+#include "ena_gpio_leds.dtsi"

--- a/samples/button/boards/picoboy_rp2040_color.overlay
+++ b/samples/button/boards/picoboy_rp2040_color.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dis_pwm_leds.dtsi"
+#include "ena_gpio_leds.dtsi"


### PR DESCRIPTION
Some boards, often RP2040-based, have only the PWM-based LEDs activated instead of the GPIO. This example requires activated GPIO LEDs in the devicetree. Special DTS overlays are now provided for this purpose:

- Cytron Maker RP2040
- The PicoBoy