### PR TITLE
feat: use volume to store upstream modules

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 	"postCreateCommand": "bash ${localWorkspaceFolderBasename}/.devcontainer/post-create.sh /workspace ${localWorkspaceFolderBasename}",
 	"postStartCommand": "bash ${localWorkspaceFolderBasename}/.devcontainer/post-start.sh /workspace",
 	// Mount and set workspace folder
-	"workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspace,type=bind",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace/${localWorkspaceFolderBasename},type=bind",
 	"workspaceFolder": "/workspace",
 	// Username in container - align with Dockerfile
 	"remoteUser": "user",
@@ -21,7 +21,9 @@
 		// Persist installed extensions in container
 		"source=bridle-devcontainer-extensions,target=/home/user/.vscode-server/extensions,type=volume",
 		// Allow attaching USB devices to running container
-		"source=/dev,target=/dev,type=bind"
+		"source=/dev,target=/dev,type=bind",
+		// Use a volume to store Zephyr modules etc.
+		"source=bridle-zephyr-modules,target=/workspace,type=volume"
 	],
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,15 +5,20 @@ REPO_NAME=$2
 
 cd $WORKSPACE_DIR
 
+# Adjust permissions as docker volumes is owned by root
+sudo chown -R $(id -g):$(id -u) $WORKSPACE_DIR
+
+# Init west workspace if not present
 if [ ! -d ".west" ]; then
     west init -l $REPO_NAME
 fi
 
+# Put .clangd file in expected location by clangd
 ln -s $REPO_NAME/.devcontainer/.clangd
 
+# Fetch upstream modules and setup tools
 west update
 west bridle-export
-
 
 pip3 install --upgrade --requirement zephyr/scripts/requirements.txt
 pip3 install --upgrade --requirement $REPO_NAME/scripts/requirements.txt


### PR DESCRIPTION
This will add named volume to store all upstream modules. As volumes are owned by the root user the post-create script is adjusted to change permissions to the devcontainer's user.