### PR TITLE
feat: update devcontainer from v4.0-branch and add documentation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Bridle",
+	"name": "${localWorkspaceFolderBasename}",
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Specify version for Zephyr Container
@@ -13,15 +13,17 @@
 	"postCreateCommand": "bash ${localWorkspaceFolderBasename}/.devcontainer/post-create.sh /workspace ${localWorkspaceFolderBasename}",
 	"postStartCommand": "bash ${localWorkspaceFolderBasename}/.devcontainer/post-start.sh /workspace",
 	// Mount and set workspace folder
-	"workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspace,type=bind",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace/${localWorkspaceFolderBasename},type=bind",
 	"workspaceFolder": "/workspace",
 	// Username in container - align with Dockerfile
 	"remoteUser": "user",
 	"mounts": [
 		// Persist installed extensions in container
-		"source=bridle-devcontainer-extensions,target=/home/user/.vscode-server/extensions,type=volume",
+		"source=${localWorkspaceFolderBasename}-devcontainer-extensions,target=/home/user/.vscode-server/extensions,type=volume",
 		// Allow attaching USB devices to running container
-		"source=/dev,target=/dev,type=bind"
+		"source=/dev,target=/dev,type=bind",
+		// Use a volume to store Zephyr modules etc.
+		"source=${localWorkspaceFolderBasename}-zephyr-modules,target=/workspace,type=volume"
 	],
 	"customizations": {
 		"vscode": {
@@ -32,7 +34,8 @@
 					"--compile-commands-dir=/workspace/build",
 					"--header-insertion=never"
 				],
-				"clangd.path": "clangd-16"
+				"clangd.path": "clangd-16",
+				"C_Cpp.intelliSenseEngine": "disabled"
 			},
 			"extensions": [
 				"marus25.cortex-debug",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,15 +5,20 @@ REPO_NAME=$2
 
 cd $WORKSPACE_DIR
 
+# Adjust permissions as docker volumes is owned by root
+sudo chown -R $(id -g):$(id -u) $WORKSPACE_DIR
+
+# Init west workspace if not present
 if [ ! -d ".west" ]; then
     west init -l $REPO_NAME
 fi
 
+# Put .clangd file in expected location by clangd
 ln -s $REPO_NAME/.devcontainer/.clangd
 
+# Fetch upstream modules and setup tools
 west update
 west bridle-export
-
 
 pip3 install --upgrade --requirement zephyr/scripts/requirements.txt
 pip3 install --upgrade --requirement $REPO_NAME/scripts/requirements.txt

--- a/doc/bridle/getting_started.rst
+++ b/doc/bridle/getting_started.rst
@@ -6,7 +6,12 @@ Getting started
 To quickly get started with |BRIDLE|, use the :ref:`Getting Started Assistant
 <gs_assistant>` to set up your development environment. Alternatively, check the
 :ref:`gs_installing` section for instructions on setting up your environment
-manually. To set up your system for using Bridle with Nix, see :ref:`gs_nix`.
+manually.
+
+Alternative ways of using some pre build environments are:
+
+* Using Bridle with Nix, see :ref:`gs_nix`
+* Using Bridle with devcontainers, see :ref:`gs_devcontainer`
 
 We recommend using [t.b.d.] for building your applications. See
 :ref:`gs_programming` for the download links and instructions. In case you
@@ -26,6 +31,7 @@ start developing!
    gs_assistant
    gs_installing
    gs_nix
+   gs_devcontainer
    gs_programming
    gs_testing
    gs_modifying

--- a/doc/bridle/gs_devcontainer.rst
+++ b/doc/bridle/gs_devcontainer.rst
@@ -1,0 +1,59 @@
+.. _gs_devcontainer:
+
+Working with Bridle via devcontainer
+####################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+An alternative way to develop with Bridle is by using `devcontainer <https://containers.dev/>`_.
+Development containers bundle all necessary tools needed in a ready to use container
+and take the effort of installing anything locally. Therefore if the development environment
+is not needed anymore you can simply remove the container and have your system as clean
+as before.
+
+Prerequisites
+*************
+
+The Bridle devcontainer setup is created and tested with `docker <https://www.docker.com/>`_ and
+`Visual Studio Code <https://code.visualstudio.com/>`_ with the `Dev Containers <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers>`_
+extension. So these three tools need to be installed on your system.
+
+You should also be able to run ``docker`` commands as your user. To test this just run ``docker ps``
+and it should print a list (might be empty) with all running containers. If you can't
+access docker without root privileges it will exit with an error.
+
+Using Bridle with devcontainer
+******************************
+
+All you have to do is checkout the bridle repository, open it in Visual Studio Code and if
+prompted select ``Reopen in Container``. Then the referenced image in ``.devcontainer/devcontainer.json``
+will be pulled and afterwards your workspace will be initialized using ``west`` automatically.
+This will take a while – depending on your internet connection.
+
+You can also start this process manually by opening the ``Command Palette`` (default shortcut
+is ``Ctrl+Shif+P``) and then search for ``Dev Containers: Reopen in container``.
+
+When this process is finished you can open up a new terminal inside of the container and get
+started with your development. Go to ``Terminal > New Terminal`` and it appears in the ``TERMINAL``
+section on the bottom of your screen.
+
+Flashing and debugging
+**********************
+
+The devcontainer mounts the entire ``/dev`` folder from the host into the container. That way
+the container is able to see new attached (or detached) devices. To be able to access those
+devices it is necessary to have the proper udev rules on your **host machine**.
+
+Windows users
+*************
+
+Visual Studio Code and docker are also available for Windows and therefore it is possible
+to run this setup also on Windows. As filesystem access from the container to your Windows filesystem
+is very slow (even on NVMe drives) it is recommended to checkout the repository in your WSL2
+home folder and start your journey from there.
+
+You can then start Visual Studio Code from your Windows machine, navigate via the ``Open Folder``
+dialog to your WSL2 filesystem, open the repository and start your devcontainer. To access USB devices
+for flashing and debugging you have to make them available in WSL2 by using `usbipd <https://learn.microsoft.com/en-us/windows/wsl/connect-usb>`_.


### PR DESCRIPTION
This will include the updated devcontainer.json from the v4.0-branch to store all the Zephyr modules in a docker volume and add some documentation on how to actually use this devcontainer.