### PR TITLE
Support the new chosen property for touch controllers

### DIFF
--- a/boards/shields/rpi_pico_bb/doc/geeekpi_pico_bb/touch_test.rsti
+++ b/boards/shields/rpi_pico_bb/doc/geeekpi_pico_bb/touch_test.rsti
@@ -1,0 +1,74 @@
+Using the :zephyr:ref:`Display driver API <display_api>` and the
+:zephyr:ref:`Input subsystem API <input>` with chosen display and
+touchscreen panel. That is:
+
+| :hwftlbl-scr:`LCD` : :dts:`chosen { zephyr,display = &lcd_panel; };`
+| :hwftlbl-scr:`ILI9341` : :dts:`lcd_panel: &ili9341_320x240 {};`
+| :hwftlbl-scr:`TSC` : :dts:`chosen { zephyr,touch = &tsc_panel; };`
+| :hwftlbl-scr:`XPT2046` : :dts:`tsc_panel: &xpt2046_240x320 {};`
+
+.. tabs::
+
+   .. group-tab:: Raspberry Pi Pico
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: geeekpi_pico_bb-touch_test
+         :board: rpi_pico
+         :shield: "geeekpi_pico_bb"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+   .. group-tab:: Raspberry Pi Pico W
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: geeekpi_pico_bb-touch_test
+         :board: rpi_pico/rp2040/w
+         :shield: "geeekpi_pico_bb"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+   .. group-tab:: Waveshare RP2040-Plus
+
+      .. rubric:: on standard ``4㎆`` revision
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: geeekpi_pico_bb-touch_test
+         :board: waveshare_rp2040_plus
+         :shield: "geeekpi_pico_bb"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+      .. rubric:: on extended ``16㎆`` revision
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: geeekpi_pico_bb-touch_test
+         :board: waveshare_rp2040_plus@16mb
+         :shield: "geeekpi_pico_bb"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+.. rubric:: Simple logging output on target
+
+.. container:: highlight highlight-console notranslate no-copybutton
+
+   .. parsed-literal::
+
+      [00:00:00.134,000] <inf> xpt2046: Init 'xpt2046\ @\ 0' device
+      \*\*\*\*\* delaying boot 4000ms (per build configuration) \*\*\*\*\*
+      [00:00:00.301,000] :byl:`<wrn> udc_rpi: BUS RESET`
+      [00:00:00.382,000] :byl:`<wrn> udc_rpi: BUS RESET`
+      \*\*\* Booting Zephyr OS build |zephyr_version_em|\ *…* (delayed boot 4000ms) \*\*\*
+      [00:00:04.135,000] <inf> sample: Touch sample for touchscreen: xpt2046\ @\ 0, dc: ili9341\ @\ 0
+      [00:00:04.136,000] :brd:`<err> sample: Unsupported BPP=0`

--- a/boards/shields/rpi_pico_bb/doc/geeekpi_pico_bb_plus/touch_test.rsti
+++ b/boards/shields/rpi_pico_bb/doc/geeekpi_pico_bb_plus/touch_test.rsti
@@ -1,0 +1,75 @@
+Using the :zephyr:ref:`Display driver API <display_api>` and the
+:zephyr:ref:`Input subsystem API <input>` with chosen display and
+touchscreen panel. That is:
+
+| :hwftlbl-scr:`LCD` : :dts:`chosen { zephyr,display = &lcd_panel; };`
+| :hwftlbl-scr:`ST7796S` : :dts:`lcd_panel: &st7796s_480x320 {};`
+| :hwftlbl-scr:`TSC` : :dts:`chosen { zephyr,touch = &tsc_panel; };`
+| :hwftlbl-scr:`GT911` : :dts:`tsc_panel: &gt911_320x480 {};`
+
+.. tabs::
+
+   .. group-tab:: Raspberry Pi Pico
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: geeekpi_pico_bb_plus-touch_test
+         :board: rpi_pico
+         :shield: "geeekpi_pico_bb_plus"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+   .. group-tab:: Raspberry Pi Pico W
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: geeekpi_pico_bb_plus-touch_test
+         :board: rpi_pico/rp2040/w
+         :shield: "geeekpi_pico_bb_plus"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+   .. group-tab:: Waveshare RP2040-Plus
+
+      .. rubric:: on standard ``4㎆`` revision
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: geeekpi_pico_bb_plus-touch_test
+         :board: waveshare_rp2040_plus
+         :shield: "geeekpi_pico_bb_plus"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+      .. rubric:: on extended ``16㎆`` revision
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: geeekpi_pico_bb_plus-touch_test
+         :board: waveshare_rp2040_plus@16mb
+         :shield: "geeekpi_pico_bb_plus"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+.. rubric:: Simple logging output on target
+
+.. container:: highlight highlight-console notranslate no-copybutton
+
+   .. parsed-literal::
+
+      \*\*\*\*\* delaying boot 4000ms (per build configuration) \*\*\*\*\*
+      [00:00:00.477,000] :byl:`<wrn> udc_rpi: BUS RESET`
+      [00:00:00.557,000] :byl:`<wrn> udc_rpi: BUS RESET`
+      \*\*\* Booting Zephyr OS build |zephyr_version_em|\ *…* (delayed boot 4000ms) \*\*\*
+      [00:00:04.319,000] <inf> sample: Touch sample for touchscreen: gt911\ @\ 5d, dc: st7796s\ @\ 0
+      [00:01:30.649,000] <inf> sample: TOUCH PRESS X, Y: (156, 130)
+      [00:01:30.751,000] <inf> sample: TOUCH PRESS X, Y: (156, 130)
+      [00:01:30.852,000] <inf> sample: TOUCH RELEASE X, Y: (156, 130)

--- a/boards/shields/rpi_pico_bb/doc/index.rst
+++ b/boards/shields/rpi_pico_bb/doc/index.rst
@@ -222,6 +222,27 @@ order. See also Zephyr sample: :zephyr:code-sample:`display`.
 
             .. include:: geeekpi_pico_bb_plus/display_test.rsti
 
+Draw touch events on LCD
+========================
+
+Draw a small plus in the last touched coordinates. In this way, parameters such
+as inverted/swapped axes can be examined. See also Zephyr sample:
+:zephyr:code-sample:`draw_touch_events`.
+
+.. tabs::
+
+   .. group-tab:: GeeekPi (Pico …)
+
+      .. tabs::
+
+         .. group-tab:: Breadboard Kit
+
+            .. include:: geeekpi_pico_bb/touch_test.rsti
+
+         .. group-tab:: Breadboard Kit Plus
+
+            .. include:: geeekpi_pico_bb_plus/touch_test.rsti
+
 LVGL Basic Sample
 =================
 

--- a/boards/shields/rpi_pico_bb/geeekpi_pico_bb.overlay
+++ b/boards/shields/rpi_pico_bb/geeekpi_pico_bb.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 TiaC Systems
+ * Copyright (c) 2024-2025 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,display = &lcd_panel;
+		zephyr,touch = &tsc_panel;
 	};
 
 	mipi_dbi: mipi-dbi {

--- a/boards/shields/rpi_pico_bb/geeekpi_pico_bb_plus.overlay
+++ b/boards/shields/rpi_pico_bb/geeekpi_pico_bb_plus.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 TiaC Systems
+ * Copyright (c) 2024-2025 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,display = &lcd_panel;
+		zephyr,touch = &tsc_panel;
 	};
 
 	mipi_dbi: mipi-dbi {

--- a/boards/shields/rpi_pico_lcd/doc/index.rst
+++ b/boards/shields/rpi_pico_lcd/doc/index.rst
@@ -529,6 +529,98 @@ order. See also Zephyr sample: :zephyr:code-sample:`display`.
 
             .. include:: waveshare_pico_restouch_lcd_3_5/display_test.rsti
 
+Draw touch events on LCD
+========================
+
+Draw a small plus in the last touched coordinates. In this way, parameters such
+as inverted/swapped axes can be examined. See also Zephyr sample:
+:zephyr:code-sample:`draw_touch_events`.
+
+.. tabs::
+
+   .. group-tab:: PiMoroni (Pico …)
+
+      .. tabs::
+
+         .. group-tab:: LCD 1.44
+
+            .. hint::
+
+               The |PiMoroni Pico LCD 1.44| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+         .. group-tab:: LCD 2
+
+            .. hint::
+
+               The |PiMoroni Pico LCD 2| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+   .. group-tab:: Spotpear (Pico …)
+
+      .. tabs::
+
+         .. group-tab:: LCD 1.54
+
+            .. hint::
+
+               The |Spotpear Pico LCD 1.54| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+   .. group-tab:: Waveshare (Pico …)
+
+      .. tabs::
+
+         .. group-tab:: LCD 0.96
+
+            .. hint::
+
+               The |Waveshare Pico LCD 0.96| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+         .. group-tab:: LCD 1.14
+
+            .. hint::
+
+               The |Waveshare Pico LCD 1.14| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+         .. group-tab:: LCD 1.3
+
+            .. hint::
+
+               The |Waveshare Pico LCD 1.3| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+         .. group-tab:: LCD 1.44
+
+            .. hint::
+
+               The |Waveshare Pico LCD 1.44| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+         .. group-tab:: LCD 1.8
+
+            .. hint::
+
+               The |Waveshare Pico LCD 1.8| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+         .. group-tab:: LCD 2
+
+            .. hint::
+
+               The |Waveshare Pico LCD 2| doesn't provide a touchscreen panel.
+               This sample is not applicable.
+
+         .. group-tab:: ResTouch LCD 2.8
+
+            .. include:: waveshare_pico_restouch_lcd_2_8/touch_test.rsti
+
+         .. group-tab:: ResTouch LCD 3.5
+
+            .. include:: waveshare_pico_restouch_lcd_3_5/touch_test.rsti
+
 LVGL Basic Sample
 =================
 

--- a/boards/shields/rpi_pico_lcd/doc/waveshare_pico_restouch_lcd_2_8/touch_test.rsti
+++ b/boards/shields/rpi_pico_lcd/doc/waveshare_pico_restouch_lcd_2_8/touch_test.rsti
@@ -1,0 +1,74 @@
+Using the :zephyr:ref:`Display driver API <display_api>` and the
+:zephyr:ref:`Input subsystem API <input>` with chosen display and
+touchscreen panel. That is:
+
+| :hwftlbl-scr:`LCD` : :dts:`chosen { zephyr,display = &lcd_panel; };`
+| :hwftlbl-scr:`ST7789V` : :dts:`lcd_panel: &st7789v_320x240 {};`
+| :hwftlbl-scr:`TSC` : :dts:`chosen { zephyr,touch = &tsc_panel; };`
+| :hwftlbl-scr:`XPT2046` : :dts:`tsc_panel: &xpt2046_240x320 {};`
+
+.. tabs::
+
+   .. group-tab:: Raspberry Pi Pico
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: waveshare_pico_restouch_lcd_2_8-touch_test
+         :board: rpi_pico
+         :shield: "waveshare_pico_restouch_lcd_2_8"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+   .. group-tab:: Raspberry Pi Pico W
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: waveshare_pico_restouch_lcd_2_8-touch_test
+         :board: rpi_pico/rp2040/w
+         :shield: "waveshare_pico_restouch_lcd_2_8"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+   .. group-tab:: Waveshare RP2040-Plus
+
+      .. rubric:: on standard ``4㎆`` revision
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: waveshare_pico_restouch_lcd_2_8-touch_test
+         :board: waveshare_rp2040_plus
+         :shield: "waveshare_pico_restouch_lcd_2_8"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+      .. rubric:: on extended ``16㎆`` revision
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: waveshare_pico_restouch_lcd_2_8-touch_test
+         :board: waveshare_rp2040_plus@16mb
+         :shield: "waveshare_pico_restouch_lcd_2_8"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+.. rubric:: Simple logging output on target
+
+.. container:: highlight highlight-console notranslate no-copybutton
+
+   .. parsed-literal::
+
+      [00:00:00.189,000] <inf> xpt2046: Init 'xpt2046\ @\ 1' device
+      \*\*\*\*\* delaying boot 4000ms (per build configuration) \*\*\*\*\*
+      [00:00:00.344,000] :byl:`<wrn> udc_rpi: BUS RESET`
+      [00:00:00.428,000] :byl:`<wrn> udc_rpi: BUS RESET`
+      \*\*\* Booting Zephyr OS build |zephyr_version_em|\ *…* (delayed boot 4000ms) \*\*\*
+      [00:00:04.191,000] <inf> sample: Touch sample for touchscreen: xpt2046\ @\ 1, dc: st7789v\ @\ 0
+      [00:00:04.192,000] :brd:`<err> sample: Unsupported BPP=0`

--- a/boards/shields/rpi_pico_lcd/doc/waveshare_pico_restouch_lcd_3_5/touch_test.rsti
+++ b/boards/shields/rpi_pico_lcd/doc/waveshare_pico_restouch_lcd_3_5/touch_test.rsti
@@ -1,0 +1,74 @@
+Using the :zephyr:ref:`Display driver API <display_api>` and the
+:zephyr:ref:`Input subsystem API <input>` with chosen display and
+touchscreen panel. That is:
+
+| :hwftlbl-scr:`LCD` : :dts:`chosen { zephyr,display = &lcd_panel; };`
+| :hwftlbl-scr:`ILI9488` : :dts:`lcd_panel: &ili9488_480x320 {};`
+| :hwftlbl-scr:`TSC` : :dts:`chosen { zephyr,touch = &tsc_panel; };`
+| :hwftlbl-scr:`XPT2046` : :dts:`tsc_panel: &xpt2046_320x480 {};`
+
+.. tabs::
+
+   .. group-tab:: Raspberry Pi Pico
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: waveshare_pico_restouch_lcd_3_5-touch_test
+         :board: rpi_pico
+         :shield: "waveshare_pico_restouch_lcd_3_5"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+   .. group-tab:: Raspberry Pi Pico W
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: waveshare_pico_restouch_lcd_3_5-touch_test
+         :board: rpi_pico/rp2040/w
+         :shield: "waveshare_pico_restouch_lcd_3_5"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+   .. group-tab:: Waveshare RP2040-Plus
+
+      .. rubric:: on standard ``4㎆`` revision
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: waveshare_pico_restouch_lcd_3_5-touch_test
+         :board: waveshare_rp2040_plus
+         :shield: "waveshare_pico_restouch_lcd_3_5"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+      .. rubric:: on extended ``16㎆`` revision
+
+      .. zephyr-app-commands::
+         :app: zephyr/samples/subsys/input/draw_touch_events
+         :build-dir: waveshare_pico_restouch_lcd_3_5-touch_test
+         :board: waveshare_rp2040_plus@16mb
+         :shield: "waveshare_pico_restouch_lcd_3_5"
+         :goals: flash
+         :west-args: -p -S usb-console
+         :flash-args: -r uf2
+         :compact:
+
+.. rubric:: Simple logging output on target
+
+.. container:: highlight highlight-console notranslate no-copybutton
+
+   .. parsed-literal::
+
+      [00:00:00.134,000] <inf> xpt2046: Init 'xpt2046\ @\ 1' device
+      \*\*\*\*\* delaying boot 4000ms (per build configuration) \*\*\*\*\*
+      [00:00:00.500,000] :byl:`<wrn> udc_rpi: BUS RESET`
+      [00:00:00.580,000] :byl:`<wrn> udc_rpi: BUS RESET`
+      \*\*\* Booting Zephyr OS build |zephyr_version_em|\ *…* (delayed boot 4000ms) \*\*\*
+      [00:00:04.136,000] <inf> sample: Touch sample for touchscreen: xpt2046\ @\ 1, dc: ili9488\ @\ 0
+      [00:00:04.136,000] :brd:`<err> sample: Unsupported BPP=0`

--- a/boards/shields/rpi_pico_lcd/waveshare_pico_restouch_lcd_2_8.overlay
+++ b/boards/shields/rpi_pico_lcd/waveshare_pico_restouch_lcd_2_8.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 TiaC Systems
+ * Copyright (c) 2024-2025 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,7 @@
 / {
 	chosen {
 		zephyr,display = &lcd_panel;
+		zephyr,touch = &tsc_panel;
 	};
 
 	mipi_dbi: mipi-dbi {

--- a/boards/shields/rpi_pico_lcd/waveshare_pico_restouch_lcd_3_5.overlay
+++ b/boards/shields/rpi_pico_lcd/waveshare_pico_restouch_lcd_3_5.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 TiaC Systems
+ * Copyright (c) 2023-2025 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,7 @@
 / {
 	chosen {
 		zephyr,display = &lcd_panel;
+		zephyr,touch = &tsc_panel;
 	};
 
 	mipi_dbi: mipi-dbi {

--- a/doc/bridle/releases/release-notes-4.1.0.rst
+++ b/doc/bridle/releases/release-notes-4.1.0.rst
@@ -16,6 +16,7 @@ Highlights
 * Hardware tweaks on RP2040 based boards are no longer required, neither
   directly at board level nor hidden in shields.
 * First evaluation against upstream boards with :zephyr:ref:`sysbuild` support.
+* First evaluation against upstream sample :zephyr:code-sample:`draw_touch_events`.
 
 .. note:: See the changelog and readme files in the component repositories
    for a detailed description of changes.
@@ -221,6 +222,7 @@ These GitHub issues were addressed since project bootstrapping:
 * :github:`298` - [FER] Remove all DTS tweaks on RP2040 based boards
 * :github:`297` - [HW] The PicoBoy Color Plus as additional board variant
 * :github:`296` - [HW] The PicoBoy Color as additional board variant
+* :github:`287` - [FER] Add touch controller to the ``/chosen`` node
 * :github:`277` - [HW] Grove Dual and LED Button Module as Shield
 * :github:`275` - [BUG] Lost Bridle's document version selector
 * :github:`274` - [FCR] Bump to Zephyr v4.0


### PR DESCRIPTION
Wherever it's possible, mostly boards or hields with a touchscreen controller (TSC panel), Bridle will use the new Zephyr upstream sample `draw_touch_events` (_Draw touch events_) for evaluation. Even for this sample the new property `zephyr,touch` to the `/chosen` node for boards and/or shields have to provide.

fixes #287 