### PR TITLE
bugfixes: switch to cmsis_6 and remove qemu_nios2

### DIFF
--- a/doc/bridle/releases/release-notes-4.2.0.rst
+++ b/doc/bridle/releases/release-notes-4.2.0.rst
@@ -217,6 +217,7 @@ Issue Related Items
 
 These GitHub issues were addressed since project bootstrapping:
 
+* :github:`320` - [BUG] CMSIS_6 module required by the ARM port for Cortex-M
 * :github:`317` - [BUG] Rename Kconfig option ``SCHED_DUMB`` and ``WAITQ_DUMB``
 * :github:`316` - [BUG] Remove Kconfig option ``ETH_STM32_HAL_MII`` and ``ETH_STM32_HAL_PHY_ADDRESS``
 * :github:`310` - [HW] STK8BA58 accelerometer

--- a/doc/bridle/shortcuts.txt
+++ b/doc/bridle/shortcuts.txt
@@ -732,9 +732,6 @@
 .. |zephyr:board:qemu_malta| replace::
    :external+zephyr:zephyr:board:`qemu_malta`
 
-.. |zephyr:board:qemu_nios2| replace::
-   :external+zephyr:zephyr:board:`qemu_nios2`
-
 .. |zephyr:board:qemu_riscv32e| replace::
    :external+zephyr:zephyr:board:`qemu_riscv32e`
 

--- a/samples/helloshell/README.rst
+++ b/samples/helloshell/README.rst
@@ -36,7 +36,6 @@ Requirements
   * |zephyr:board:qemu_riscv64|
   * |zephyr:board:qemu_xtensa|
   * |zephyr:board:qemu_leon3|
-  * |zephyr:board:qemu_nios2|
   * |zephyr:board:nucleo_f303re| (NUCLEO-F303RE)
   * |zephyr:board:nucleo_f401re| (NUCLEO-F401RE)
   * |zephyr:board:nucleo_f413zh| (NUCLEO-F413ZH)

--- a/samples/helloshell/sample.yaml
+++ b/samples/helloshell/sample.yaml
@@ -51,7 +51,6 @@ common:
     - qemu_xtensa/dc233c
     - qemu_xtensa/dc233c/mmu
     - qemu_leon3
-    - qemu_nios2
     - arduino_zero
     - cytron_maker_nano_rp2040
     - cytron_maker_pi_rp2040

--- a/submanifests/zephyr.yml
+++ b/submanifests/zephyr.yml
@@ -53,6 +53,7 @@ manifest:
           - canopennode
           - chre
           - cmsis
+          - cmsis_6
           - edtt
           - fatfs
           - hal_adi

--- a/tests/bridle/common/testcase.yaml
+++ b/tests/bridle/common/testcase.yaml
@@ -46,7 +46,6 @@ common:
     - qemu_xtensa/dc233c
     - qemu_xtensa/dc233c/mmu
     - qemu_leon3
-    - qemu_nios2
 tests:
   bridle.common:
     build_on_all: true


### PR DESCRIPTION
- Cortex-M now requires using the cmsis_6 module. (fix #320)
- With upcoming Zephyr 4.2 the Nios2 architecture and all related board definitions will be removed.