### PR TITLE
manifest: support Bouffalo Lab HAL

### DIFF
--- a/submanifests/zephyr.yml
+++ b/submanifests/zephyr.yml
@@ -60,6 +60,7 @@ manifest:
           - hal_altera
           - hal_ambiq
           - hal_atmel
+          - hal_bouffalolab
           - hal_espressif
           - hal_ethos_u
           - hal_gigadevice


### PR DESCRIPTION
Fix full featured documentation build process. Build the auto generated HW feature table w/o errors, e.g.:

- `west build -b bl604e_iot_dvk/bl604e20q2i -p -d build/bl604e_iot_dvk zephyr/samples/hello_world`
- `west build -b ai_wb2_12f/bl602c00q2i -p -d build/ai_wb2_12f zephyr/samples/hello_world`