### PR TITLE
SC18IS604 I2C Controller: Various Improvements and Fixes

### DIFF
--- a/drivers/gpio/gpio_sc18is604.c
+++ b/drivers/gpio/gpio_sc18is604.c
@@ -72,11 +72,10 @@ struct gpio_sc18is604_data {
 	uint8_t pin_state;
 };
 
-static int gpio_sc18is604_pin_write_config(const struct device *dev,
-					   uint8_t val)
+static int gpio_sc18is604_pin_write_config(const struct device *dev, uint8_t val)
 {
-	const struct gpio_sc18is604_config * const config = dev->config;
-	struct gpio_sc18is604_data * const data = dev->data;
+	const struct gpio_sc18is604_config *const config = dev->config;
+	struct gpio_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	ret = WRITE_SC18IS604_REG(config->bridge, IO_CONFIG, val);
@@ -94,11 +93,10 @@ end:
 	return ret;
 }
 
-static int gpio_sc18is604_pin_read_config(const struct device *dev,
-					  uint8_t *val)
+static int gpio_sc18is604_pin_read_config(const struct device *dev, uint8_t *val)
 {
-	const struct gpio_sc18is604_config * const config = dev->config;
-	struct gpio_sc18is604_data * const data = dev->data;
+	const struct gpio_sc18is604_config *const config = dev->config;
+	struct gpio_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	ret = READ_SC18IS604_REG(config->bridge, IO_CONFIG, val);
@@ -116,11 +114,10 @@ end:
 	return ret;
 }
 
-static int gpio_sc18is604_pin_write_state(const struct device *dev,
-					  uint8_t val)
+static int gpio_sc18is604_pin_write_state(const struct device *dev, uint8_t val)
 {
-	const struct gpio_sc18is604_config * const config = dev->config;
-	struct gpio_sc18is604_data * const data = dev->data;
+	const struct gpio_sc18is604_config *const config = dev->config;
+	struct gpio_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	ret = WRITE_SC18IS604_REG(config->bridge, IO_STATE, val);
@@ -138,11 +135,10 @@ end:
 	return ret;
 }
 
-static int gpio_sc18is604_pin_read_state(const struct device *dev,
-					 uint8_t *val)
+static int gpio_sc18is604_pin_read_state(const struct device *dev, uint8_t *val)
 {
-	const struct gpio_sc18is604_config * const config = dev->config;
-	struct gpio_sc18is604_data * const data = dev->data;
+	const struct gpio_sc18is604_config *const config = dev->config;
+	struct gpio_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	ret = READ_SC18IS604_REG(config->bridge, IO_STATE, val);
@@ -160,10 +156,10 @@ end:
 	return ret;
 }
 
-static int gpio_sc18is604_pin_configure(const struct device *dev,
-					gpio_pin_t pin, gpio_flags_t flags)
+static int gpio_sc18is604_pin_configure(const struct device *dev, gpio_pin_t pin,
+					gpio_flags_t flags)
 {
-	struct gpio_sc18is604_data * const data = dev->data;
+	struct gpio_sc18is604_data *const data = dev->data;
 	uint8_t shift, bits, pin_config, pin_state;
 	int ret = 0;
 
@@ -179,7 +175,7 @@ static int gpio_sc18is604_pin_configure(const struct device *dev,
 		if (pin >= SC18IS604_IO_NUM_PINS_MAX) {
 			return -ENOTSUP;
 
-		/* SC18IS604_IO_NUM_PINS_MAX - SC18IS604_IO_NUM_PINS_INOUT */
+			/* SC18IS604_IO_NUM_PINS_MAX - SC18IS604_IO_NUM_PINS_INOUT */
 		} else if ((flags & GPIO_INPUT) == GPIO_INPUT) {
 
 			/*
@@ -274,10 +270,9 @@ end:
 	return ret;
 }
 
-static int gpio_sc18is604_set_masked_raw(const struct device *dev,
-					 uint32_t mask, uint32_t value)
+static int gpio_sc18is604_set_masked_raw(const struct device *dev, uint32_t mask, uint32_t value)
 {
-	struct gpio_sc18is604_data * const data = dev->data;
+	struct gpio_sc18is604_data *const data = dev->data;
 	uint8_t pin_state;
 
 	/* Can't do operations from an ISR */
@@ -309,7 +304,7 @@ static int gpio_sc18is604_clear_bits_raw(const struct device *dev, uint32_t pins
 
 static int gpio_sc18is604_toggle_bits(const struct device *dev, uint32_t pins)
 {
-	struct gpio_sc18is604_data * const data = dev->data;
+	struct gpio_sc18is604_data *const data = dev->data;
 	uint8_t pin_state;
 
 	/* Can't do operations from an ISR */
@@ -340,14 +335,13 @@ static const struct gpio_driver_api gpio_sc18is604_api = {
 
 static int gpio_sc18is604_init(const struct device *dev)
 {
-	const struct gpio_sc18is604_config * const config = dev->config;
-	struct gpio_sc18is604_data * const data = dev->data;
+	const struct gpio_sc18is604_config *const config = dev->config;
+	struct gpio_sc18is604_data *const data = dev->data;
 	uint8_t buf;
 
 	/* Check MFD (bridge) readiness */
 	if (!device_is_ready(config->bridge)) {
-		LOG_ERR("%s: bridge device %s not ready",
-			dev->name, config->bridge->name);
+		LOG_ERR("%s: bridge device %s not ready", dev->name, config->bridge->name);
 		return -ENODEV;
 	}
 
@@ -357,8 +351,8 @@ static int gpio_sc18is604_init(const struct device *dev)
 	gpio_sc18is604_pin_read_state(dev, &buf);
 	gpio_sc18is604_pin_read_config(dev, &buf);
 
-	LOG_DBG("%s: ready for %u pins with bridge backend over %s!",
-		dev->name, config->num_pins, config->bridge->name);
+	LOG_DBG("%s: ready for %u pins with bridge backend over %s!", dev->name, config->num_pins,
+		config->bridge->name);
 	return 0;
 }
 
@@ -373,31 +367,25 @@ static int gpio_sc18is604_pm_device_pm_action(const struct device *dev,
 }
 #endif
 
-#define GPIO_SC18IS604_DEFINE(inst)                                          \
-                                                                             \
-	static const                                                         \
-	struct gpio_sc18is604_config gpio_sc18is604_config_##inst =          \
-	{                                                                    \
-		.common = {                                                  \
-			.port_pin_mask =                                     \
-				GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),       \
-		},                                                           \
-		.num_pins = DT_INST_PROP(inst, ngpios),                      \
-		.bridge = DEVICE_DT_GET(DT_INST_BUS(inst)),                  \
-	};                                                                   \
-	BUILD_ASSERT(                                                        \
-		DT_INST_PROP(inst, ngpios) <= SC18IS604_IO_NUM_PINS_MAX,     \
-		"Too many ngpios");                                          \
-                                                                             \
-	static struct gpio_sc18is604_data gpio_sc18is604_data_##inst;        \
-                                                                             \
-	PM_DEVICE_DT_INST_DEFINE(inst, gpio_sc18is604_pm_device_pm_action);  \
-                                                                             \
-	DEVICE_DT_INST_DEFINE(inst, gpio_sc18is604_init,                     \
-			      PM_DEVICE_DT_INST_GET(inst),                   \
-			      &gpio_sc18is604_data_##inst,                   \
-			      &gpio_sc18is604_config_##inst, POST_KERNEL,    \
-			      CONFIG_GPIO_SC18IS604_INIT_PRIORITY,           \
+#define GPIO_SC18IS604_DEFINE(inst)                                                                \
+                                                                                                   \
+	static const struct gpio_sc18is604_config gpio_sc18is604_config_##inst = {                 \
+		.common =                                                                          \
+			{                                                                          \
+				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),            \
+			},                                                                         \
+		.num_pins = DT_INST_PROP(inst, ngpios),                                            \
+		.bridge = DEVICE_DT_GET(DT_INST_BUS(inst)),                                        \
+	};                                                                                         \
+	BUILD_ASSERT(DT_INST_PROP(inst, ngpios) <= SC18IS604_IO_NUM_PINS_MAX, "Too many ngpios");  \
+                                                                                                   \
+	static struct gpio_sc18is604_data gpio_sc18is604_data_##inst;                              \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, gpio_sc18is604_pm_device_pm_action);                        \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, gpio_sc18is604_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &gpio_sc18is604_data_##inst, &gpio_sc18is604_config_##inst,          \
+			      POST_KERNEL, CONFIG_GPIO_SC18IS604_INIT_PRIORITY,                    \
 			      &gpio_sc18is604_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_SC18IS604_DEFINE);

--- a/drivers/i2c/Kconfig.sc18is604
+++ b/drivers/i2c/Kconfig.sc18is604
@@ -7,9 +7,7 @@ menuconfig I2C_SC18IS604
 	depends on DT_HAS_NXP_SC18IS604_I2C_ENABLED
 	depends on MFD_SC18IS604
 	select MFD_SC18IS604_ASYNC
-	select POLL              # dependency of MFD_SC18IS604_ASYNC
-	select DYNAMIC_THREAD    # dependency of MFD_SC18IS604_ASYNC
-	select THREAD_STACK_INFO # dependency of DYNAMIC_THREAD
+	select POLL # dependency of MFD_SC18IS604_ASYNC
 	help
 	  Enable driver for I2C controller part of an SC18IM604 bridge.
 
@@ -19,6 +17,10 @@ config I2C_SC18IS604_INIT_PRIORITY
 	depends on I2C_SC18IS604
 	help
 	  Device driver initialization priority.
+
+config I2C_SC18IS604_WORKQUEUE_STACK_SIZE
+	int
+	default 512
 
 if I2C_SC18IS604 && I2C_CALLBACK
 
@@ -30,4 +32,4 @@ config HEAP_MEM_POOL_ADD_SIZE_I2C_SC18IS604
 	int
 	default 512 # Enough for 5 in-flight async transfers
 
-endif
+endif # I2C_CALLBACK

--- a/drivers/i2c/i2c_sc18is604.c
+++ b/drivers/i2c/i2c_sc18is604.c
@@ -43,9 +43,7 @@ LOG_MODULE_REGISTER(sc18is604_i2c, CONFIG_I2C_LOG_LEVEL);
 int await_signal(struct k_poll_signal *signal, int *result, k_timeout_t timeout)
 {
 	struct k_poll_event events[1] = {
-		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL,
-					 K_POLL_MODE_NOTIFY_ONLY,
-					 signal),
+		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, signal),
 	};
 
 	k_poll(events, 1, timeout);
@@ -60,10 +58,10 @@ int await_signal(struct k_poll_signal *signal, int *result, k_timeout_t timeout)
 /* Initialize reading out the interrupt source. */
 static void i2c_sc18is604_interrupt_work_fn_initial(struct k_work *work)
 {
-	struct i2c_sc18is604_data * const data = CONTAINER_OF(work,
-			struct i2c_sc18is604_data, interrupt_work_initial);
+	struct i2c_sc18is604_data *const data =
+		CONTAINER_OF(work, struct i2c_sc18is604_data, interrupt_work_initial);
 	const struct device *dev = data->dev;
-	const struct i2c_sc18is604_config * const config = dev->config;
+	const struct i2c_sc18is604_config *const config = dev->config;
 	int ret = 0;
 
 	/* Soft spinning on interrupt handling lock */
@@ -104,15 +102,13 @@ static void i2c_sc18is604_interrupt_work_fn_initial(struct k_work *work)
 /* Await the result of reading out the interrupt source and act on it. */
 static void i2c_sc18is604_interrupt_work_fn_final(struct k_work *work)
 {
-	struct k_work_delayable *work_delayable = CONTAINER_OF(work,
-					struct k_work_delayable, work);
-	struct i2c_sc18is604_data * const data = CONTAINER_OF(work_delayable,
-			struct i2c_sc18is604_data, interrupt_work_final);
+	struct k_work_delayable *work_delayable = CONTAINER_OF(work, struct k_work_delayable, work);
+	struct i2c_sc18is604_data *const data =
+		CONTAINER_OF(work_delayable, struct i2c_sc18is604_data, interrupt_work_final);
 
 	/* Check result of i2c status readout */
 	int result = 0;
-	int signaled = await_signal(&data->interrupt_handling_data.signal,
-				    &result, K_NO_WAIT);
+	int signaled = await_signal(&data->interrupt_handling_data.signal, &result, K_NO_WAIT);
 
 	if (!signaled) {
 		/* Transfer not complete, keep spinning */
@@ -127,8 +123,7 @@ static void i2c_sc18is604_interrupt_work_fn_final(struct k_work *work)
 	}
 
 	/* Otherwise, propagate the received status via signal */
-	k_poll_signal_raise(&data->interrupt_signal,
-			    data->interrupt_handling_data.i2cstat);
+	k_poll_signal_raise(&data->interrupt_signal, data->interrupt_handling_data.i2cstat);
 
 end:
 	/* Release interrupt handling lock */
@@ -139,12 +134,11 @@ end:
  * Interrupt callback that is registered with the parent MFD which runs in ISR
  * context.
  */
-static void i2c_sc18is604_interrupt_callback(const struct device *dev,
-					     struct gpio_callback *cb,
+static void i2c_sc18is604_interrupt_callback(const struct device *dev, struct gpio_callback *cb,
 					     gpio_port_pins_t pins)
 {
-	struct i2c_sc18is604_data * const data = CONTAINER_OF(cb,
-			struct i2c_sc18is604_data, interrupt_cb);
+	struct i2c_sc18is604_data *const data =
+		CONTAINER_OF(cb, struct i2c_sc18is604_data, interrupt_cb);
 
 	/*
 	 * Reading out the interrupt source requires bus communication, so we do
@@ -153,10 +147,9 @@ static void i2c_sc18is604_interrupt_callback(const struct device *dev,
 	k_work_submit(&data->interrupt_work_initial);
 }
 
-static inline int i2c_sc18is604_set_clock_speed(const struct device *dev,
-						uint32_t speed)
+static inline int i2c_sc18is604_set_clock_speed(const struct device *dev, uint32_t speed)
 {
-	const struct i2c_sc18is604_config * const config = dev->config;
+	const struct i2c_sc18is604_config *const config = dev->config;
 	uint8_t value;
 
 	switch (speed) {
@@ -173,32 +166,26 @@ static inline int i2c_sc18is604_set_clock_speed(const struct device *dev,
 	return WRITE_SC18IS604_REG(config->parent_dev, I2C_CLOCK, value);
 }
 
-static int i2c_sc18is604_write_message(const struct device *dev,
-				       uint8_t *data, size_t len,
+static int i2c_sc18is604_write_message(const struct device *dev, uint8_t *data, size_t len,
 				       uint16_t addr)
 {
-	const struct i2c_sc18is604_config * const config = dev->config;
-	struct i2c_sc18is604_data * const drv_data = dev->data;
+	const struct i2c_sc18is604_config *const config = dev->config;
+	struct i2c_sc18is604_data *const drv_data = dev->data;
 	int ret;
 
-	uint8_t cmd[] = {
-		SC18IS604_CMD_WRITE_I2C,
-		len, (uint8_t) addr
-	};
+	uint8_t cmd[] = {SC18IS604_CMD_WRITE_I2C, len, (uint8_t)addr};
 
 	/* Reset interrupt signal */
 	k_poll_signal_reset(&drv_data->interrupt_signal);
 
 	/* Send 'I2C WRITE' command with data attached */
-	ret = mfd_sc18is604_transfer(config->parent_dev, cmd, ARRAY_SIZE(cmd),
-							 data, len, NULL, 0);
+	ret = mfd_sc18is604_transfer(config->parent_dev, cmd, ARRAY_SIZE(cmd), data, len, NULL, 0);
 	if (ret != 0) {
 		return ret;
 	}
 	/* Await interrupt signal */
 	int result = 0;
-	int signaled = await_signal(&drv_data->interrupt_signal,
-				    &result, K_FOREVER);
+	int signaled = await_signal(&drv_data->interrupt_signal, &result, K_FOREVER);
 
 	if (!signaled) {
 		return -EIO;
@@ -211,18 +198,14 @@ static int i2c_sc18is604_write_message(const struct device *dev,
 	return 0;
 }
 
-static int i2c_sc18is604_read_message(const struct device *dev,
-				      uint8_t *data, size_t len,
+static int i2c_sc18is604_read_message(const struct device *dev, uint8_t *data, size_t len,
 				      uint16_t addr)
 {
-	const struct i2c_sc18is604_config * const config = dev->config;
-	struct i2c_sc18is604_data * const drv_data = dev->data;
+	const struct i2c_sc18is604_config *const config = dev->config;
+	struct i2c_sc18is604_data *const drv_data = dev->data;
 	int ret = 0;
 
-	uint8_t cmd[] = {
-		SC18IS604_CMD_READ_I2C,
-		len, (uint8_t) addr
-	};
+	uint8_t cmd[] = {SC18IS604_CMD_READ_I2C, len, (uint8_t)addr};
 
 	/* Claim lock on MFD */
 	mfd_sc18is604_claim(config->parent_dev, K_FOREVER);
@@ -231,16 +214,14 @@ static int i2c_sc18is604_read_message(const struct device *dev,
 	k_poll_signal_reset(&drv_data->interrupt_signal);
 
 	/* Send 'I2C READ' command */
-	ret = mfd_sc18is604_transfer(config->parent_dev, cmd, ARRAY_SIZE(cmd),
-							 NULL, 0, NULL, 0);
+	ret = mfd_sc18is604_transfer(config->parent_dev, cmd, ARRAY_SIZE(cmd), NULL, 0, NULL, 0);
 	if (ret != 0) {
 		goto release_and_return;
 	}
 
 	/* Await interrupt signal */
 	int result = 0;
-	int signaled = await_signal(&drv_data->interrupt_signal,
-				    &result, K_FOREVER);
+	int signaled = await_signal(&drv_data->interrupt_signal, &result, K_FOREVER);
 
 	if (!signaled) {
 		ret = -EIO;
@@ -253,7 +234,7 @@ static int i2c_sc18is604_read_message(const struct device *dev,
 	}
 
 	/* Read out the received data */
-	ret =  mfd_sc18is604_read_buffer(config->parent_dev, data, len);
+	ret = mfd_sc18is604_read_buffer(config->parent_dev, data, len);
 	if (ret != 0) {
 		ret = -EIO;
 		goto release_and_return;
@@ -266,7 +247,7 @@ release_and_return:
 
 static int i2c_sc18is604_configure(const struct device *dev, uint32_t config)
 {
-	struct i2c_sc18is604_data * const data = dev->data;
+	struct i2c_sc18is604_data *const data = dev->data;
 
 	/* Device can only act as controller */
 	if ((config & I2C_MODE_CONTROLLER) != I2C_MODE_CONTROLLER) {
@@ -287,8 +268,7 @@ static int i2c_sc18is604_configure(const struct device *dev, uint32_t config)
 		 * Controller only supports 'standard' (100kHz) and 'fast'
 		 * (400kHz) speeds.
 		 */
-		if ((speed == I2C_SPEED_STANDARD) ||
-			(speed == I2C_SPEED_FAST)) {
+		if ((speed == I2C_SPEED_STANDARD) || (speed == I2C_SPEED_FAST)) {
 
 			int ret = i2c_sc18is604_set_clock_speed(dev, speed);
 
@@ -309,13 +289,12 @@ static int i2c_sc18is604_configure(const struct device *dev, uint32_t config)
 
 static int i2c_sc18is604_get_config(const struct device *dev, uint32_t *config)
 {
-	const struct i2c_sc18is604_data * const data = dev->data;
+	const struct i2c_sc18is604_data *const data = dev->data;
 	*config = data->i2c_config;
 	return 0;
 }
 
-static int i2c_sc18is604_transfer_msg(const struct device *dev,
-				      struct i2c_msg *msg, uint16_t addr)
+static int i2c_sc18is604_transfer_msg(const struct device *dev, struct i2c_msg *msg, uint16_t addr)
 {
 	/* Device doesn't support 10bit addressing */
 	if ((msg->flags & I2C_MSG_ADDR_10_BITS) == I2C_MSG_ADDR_10_BITS) {
@@ -327,23 +306,19 @@ static int i2c_sc18is604_transfer_msg(const struct device *dev,
 	addr |= (msg->flags & I2C_MSG_RW_MASK);
 
 	if ((msg->flags & I2C_MSG_READ) == I2C_MSG_READ) {
-		return i2c_sc18is604_read_message(dev, msg->buf,
-						  msg->len, addr);
+		return i2c_sc18is604_read_message(dev, msg->buf, msg->len, addr);
 	} else {
-		return i2c_sc18is604_write_message(dev, msg->buf,
-						   msg->len, addr);
+		return i2c_sc18is604_write_message(dev, msg->buf, msg->len, addr);
 	}
 
 	/* Should be unreachable */
 	return -EINVAL;
 }
 
-static int i2c_sc18is604_transfer(const struct device *dev,
-				  struct i2c_msg *msgs,
-				  uint8_t num_msgs,
+static int i2c_sc18is604_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
 				  uint16_t addr)
 {
-	struct i2c_sc18is604_data * const data = dev->data;
+	struct i2c_sc18is604_data *const data = dev->data;
 	int ret;
 
 	if (num_msgs == 0) {
@@ -378,14 +353,13 @@ static const struct i2c_driver_api i2c_sc18is604_api = {
 
 static int i2c_sc18is604_init(const struct device *dev)
 {
-	const struct i2c_sc18is604_config * const config = dev->config;
-	struct i2c_sc18is604_data * const data = dev->data;
+	const struct i2c_sc18is604_config *const config = dev->config;
+	struct i2c_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	/* Check parent bus readiness */
 	if (!device_is_ready(config->parent_dev)) {
-		LOG_ERR("%s: bridge device %s not ready",
-			dev->name, config->parent_dev->name);
+		LOG_ERR("%s: bridge device %s not ready", dev->name, config->parent_dev->name);
 		return -ENODEV;
 	}
 
@@ -400,32 +374,27 @@ static int i2c_sc18is604_init(const struct device *dev)
 	k_poll_signal_init(&data->interrupt_signal);
 
 	/* Register interrupt callback with parent MFD */
-	gpio_init_callback(&data->interrupt_cb,
-			   i2c_sc18is604_interrupt_callback, 0xffffffff);
+	gpio_init_callback(&data->interrupt_cb, i2c_sc18is604_interrupt_callback, 0xffffffff);
 	ret = mfd_sc18is604_add_callback(config->parent_dev, &data->interrupt_cb);
 	if (ret != 0) {
-		LOG_ERR("%s: failed to register interrupt callback on %s: %d",
-			dev->name, config->parent_dev->name, ret);
+		LOG_ERR("%s: failed to register interrupt callback on %s: %d", dev->name,
+			config->parent_dev->name, ret);
 		return ret;
 	}
 
 	/* Set up work items for interrupt handling */
-	k_work_init(&data->interrupt_work_initial,
-		    i2c_sc18is604_interrupt_work_fn_initial);
-	k_work_init_delayable(&data->interrupt_work_final,
-			      i2c_sc18is604_interrupt_work_fn_final);
+	k_work_init(&data->interrupt_work_initial, i2c_sc18is604_interrupt_work_fn_initial);
+	k_work_init_delayable(&data->interrupt_work_final, i2c_sc18is604_interrupt_work_fn_final);
 
 	/* Initialize data used by interrupt handling work items */
 	k_poll_signal_init(&data->interrupt_handling_data.signal);
 
-	LOG_DBG("%s: ready over %s!", dev->name,
-		config->parent_dev->name);
+	LOG_DBG("%s: ready over %s!", dev->name, config->parent_dev->name);
 	return 0;
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int i2c_sc18is604_pm_device_pm_action(const struct device *dev,
-					     enum pm_device_action action)
+static int i2c_sc18is604_pm_device_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(action);
@@ -434,23 +403,19 @@ static int i2c_sc18is604_pm_device_pm_action(const struct device *dev,
 }
 #endif
 
-#define I2C_SC18IS604_DEFINE(inst)                                            \
-                                                                              \
-	static const                                                          \
-	struct i2c_sc18is604_config i2c_sc18is604_config_##inst =             \
-	{                                                                     \
-		.parent_dev = DEVICE_DT_GET(DT_INST_BUS(inst)),               \
-	};                                                                    \
-                                                                              \
-	static struct i2c_sc18is604_data i2c_sc18is604_data_##inst = { };     \
-                                                                              \
-	PM_DEVICE_DT_INST_DEFINE(inst, i2c_sc18is604_pm_device_pm_action);    \
-                                                                              \
-	DEVICE_DT_INST_DEFINE(inst, i2c_sc18is604_init,                       \
-			      PM_DEVICE_DT_INST_GET(inst),                    \
-			      &i2c_sc18is604_data_##inst,                     \
-			      &i2c_sc18is604_config_##inst, POST_KERNEL,      \
-			      CONFIG_I2C_SC18IS604_INIT_PRIORITY,             \
+#define I2C_SC18IS604_DEFINE(inst)                                                                 \
+                                                                                                   \
+	static const struct i2c_sc18is604_config i2c_sc18is604_config_##inst = {                   \
+		.parent_dev = DEVICE_DT_GET(DT_INST_BUS(inst)),                                    \
+	};                                                                                         \
+                                                                                                   \
+	static struct i2c_sc18is604_data i2c_sc18is604_data_##inst = {};                           \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, i2c_sc18is604_pm_device_pm_action);                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, i2c_sc18is604_init, PM_DEVICE_DT_INST_GET(inst),               \
+			      &i2c_sc18is604_data_##inst, &i2c_sc18is604_config_##inst,            \
+			      POST_KERNEL, CONFIG_I2C_SC18IS604_INIT_PRIORITY,                     \
 			      &i2c_sc18is604_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_SC18IS604_DEFINE);

--- a/drivers/i2c/i2c_sc18is604.h
+++ b/drivers/i2c/i2c_sc18is604.h
@@ -63,6 +63,10 @@ struct i2c_sc18is604_data {
 		uint8_t i2cstat;
 		struct k_poll_signal signal;
 	} interrupt_handling_data;
+	/** Driver workqueue */
+	struct k_work_q work_queue;
+	/** Stack for driver workqueue */
+	k_thread_stack_t *work_queue_stack;
 };
 
 /**

--- a/drivers/i2c/i2c_sc18is604.h
+++ b/drivers/i2c/i2c_sc18is604.h
@@ -77,8 +77,7 @@ struct i2c_sc18is604_data {
  * @retval 0 If the signal was not raised within the timeout.
  * @return Negative error code if some failure occurs during k_poll().
  */
-int await_signal(struct k_poll_signal *signal,
-		 int *result, k_timeout_t timeout);
+int await_signal(struct k_poll_signal *signal, int *result, k_timeout_t timeout);
 
 /**
  * @brief Transfer I2C messages asynchronously.
@@ -91,10 +90,8 @@ int await_signal(struct k_poll_signal *signal,
  * @param cb Callback to be invoked on transfer completion (or failure).
  * @param userdata User data passed to callback.
  */
-int i2c_sc18is604_transfer_cb(const struct device *dev,
-			      struct i2c_msg *msgs, uint8_t num_msgs,
-			      uint16_t addr,
-			      i2c_callback_t cb, void *userdata);
+int i2c_sc18is604_transfer_cb(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			      uint16_t addr, i2c_callback_t cb, void *userdata);
 
 /** @} */
 

--- a/drivers/i2c/i2c_sc18is604_callback.c
+++ b/drivers/i2c/i2c_sc18is604_callback.c
@@ -68,12 +68,11 @@ struct i2c_sc18is604_xfr_cb_work {
  * Finish an asynchronous transfer with some result,
  * cleaning up locks and resources.
  */
-static void i2c_sc18is604_transfer_cb_process_done(
-		struct i2c_sc18is604_xfr_cb_work *transfer_work,
-		int result)
+static void i2c_sc18is604_transfer_cb_process_done(struct i2c_sc18is604_xfr_cb_work *transfer_work,
+						   int result)
 {
 	const struct device *dev = transfer_work->dev;
-	struct i2c_sc18is604_data * const data = dev->data;
+	struct i2c_sc18is604_data *const data = dev->data;
 
 	/* Release driver lock */
 	k_sem_give(&data->lock);
@@ -88,21 +87,18 @@ static void i2c_sc18is604_transfer_cb_process_done(
 	cb(dev, result, userdata);
 }
 
-static void i2c_sc18is604_init_msg_read(
-		struct i2c_sc18is604_xfr_cb_work *transfer_work,
-		uint16_t addr, struct i2c_msg *msg)
+static void i2c_sc18is604_init_msg_read(struct i2c_sc18is604_xfr_cb_work *transfer_work,
+					uint16_t addr, struct i2c_msg *msg)
 {
 	const struct device *dev = transfer_work->dev;
-	const struct i2c_sc18is604_config * const config = dev->config;
+	const struct i2c_sc18is604_config *const config = dev->config;
 	int ret = 0;
 
 	/* Call asynchronous transfer function with our internal signal. */
-	uint8_t cmd[] = {SC18IS604_CMD_READ_I2C, msg->len, (uint8_t) addr};
+	uint8_t cmd[] = {SC18IS604_CMD_READ_I2C, msg->len, (uint8_t)addr};
 
-	ret = mfd_sc18is604_transfer_signal(config->parent_dev,
-					    cmd, ARRAY_SIZE(cmd),
-					    NULL, 0, NULL, 0,
-					    &transfer_work->signal);
+	ret = mfd_sc18is604_transfer_signal(config->parent_dev, cmd, ARRAY_SIZE(cmd), NULL, 0, NULL,
+					    0, &transfer_work->signal);
 	if (ret != 0) {
 		mfd_sc18is604_release(config->parent_dev);
 		i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
@@ -118,22 +114,18 @@ static void i2c_sc18is604_init_msg_read(
 	}
 }
 
-static void i2c_sc18is604_init_msg_write(
-		struct i2c_sc18is604_xfr_cb_work *transfer_work,
-		 uint16_t addr, struct i2c_msg *msg)
+static void i2c_sc18is604_init_msg_write(struct i2c_sc18is604_xfr_cb_work *transfer_work,
+					 uint16_t addr, struct i2c_msg *msg)
 {
 	const struct device *dev = transfer_work->dev;
-	const struct i2c_sc18is604_config * const config = dev->config;
+	const struct i2c_sc18is604_config *const config = dev->config;
 	int ret = 0;
 
-	uint8_t cmd[] = {SC18IS604_CMD_WRITE_I2C, msg->len, (uint8_t) addr};
+	uint8_t cmd[] = {SC18IS604_CMD_WRITE_I2C, msg->len, (uint8_t)addr};
 
 	/* Call asynchronous transfer function with our internal signal. */
-	ret = mfd_sc18is604_transfer_signal(config->parent_dev,
-					    cmd, ARRAY_SIZE(cmd),
-					    msg->buf, msg->len,
-					    NULL, 0,
-					    &transfer_work->signal);
+	ret = mfd_sc18is604_transfer_signal(config->parent_dev, cmd, ARRAY_SIZE(cmd), msg->buf,
+					    msg->len, NULL, 0, &transfer_work->signal);
 	if (ret != 0) {
 		i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
 		return;
@@ -149,10 +141,10 @@ static void i2c_sc18is604_init_msg_write(
 
 static void i2c_sc18is604_init_msg_work_fn(struct k_work *work)
 {
-	struct i2c_sc18is604_xfr_cb_work *transfer_work = CONTAINER_OF(work,
-			struct i2c_sc18is604_xfr_cb_work, work_init_msg);
+	struct i2c_sc18is604_xfr_cb_work *transfer_work =
+		CONTAINER_OF(work, struct i2c_sc18is604_xfr_cb_work, work_init_msg);
 	const struct device *dev = transfer_work->dev;
-	struct i2c_sc18is604_data * const data = dev->data;
+	struct i2c_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	/* Get device lock, or reschedule to retry later */
@@ -161,8 +153,7 @@ static void i2c_sc18is604_init_msg_work_fn(struct k_work *work)
 		if (ret != 0) {
 			ret = k_work_submit(work);
 			if (ret != 1 && ret != 0) {
-				i2c_sc18is604_transfer_cb_process_done(
-							transfer_work, -EIO);
+				i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
 				return;
 			}
 			return;
@@ -212,23 +203,21 @@ static void i2c_sc18is604_init_msg_work_fn(struct k_work *work)
 
 static void i2c_sc18is604_buffer_readout_work_fn(struct k_work *work)
 {
-	struct i2c_sc18is604_xfr_cb_work *transfer_work = CONTAINER_OF(work,
-			struct i2c_sc18is604_xfr_cb_work, work_buffer_readout);
+	struct i2c_sc18is604_xfr_cb_work *transfer_work =
+		CONTAINER_OF(work, struct i2c_sc18is604_xfr_cb_work, work_buffer_readout);
 	const struct device *dev = transfer_work->dev;
-	const struct i2c_sc18is604_config * const config = dev->config;
-	struct i2c_sc18is604_data * const data = dev->data;
+	const struct i2c_sc18is604_config *const config = dev->config;
+	struct i2c_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	/* Await completion of the previous transfer */
 	int result = 0;
-	int signaled = await_signal(&transfer_work->signal,
-				    &result, K_NO_WAIT);
+	int signaled = await_signal(&transfer_work->signal, &result, K_NO_WAIT);
 
 	if (!signaled) {
 		ret = k_work_submit(work);
 		if (ret != 1 && ret != 0) {
-			i2c_sc18is604_transfer_cb_process_done(
-						transfer_work, -EIO);
+			i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
 			return;
 		}
 		return;
@@ -248,8 +237,7 @@ static void i2c_sc18is604_buffer_readout_work_fn(struct k_work *work)
 		 */
 		ret = k_work_submit(work);
 		if (ret != 1 && ret != 0) {
-			i2c_sc18is604_transfer_cb_process_done(
-						transfer_work, -EIO);
+			i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
 			return;
 		}
 		return;
@@ -271,8 +259,7 @@ static void i2c_sc18is604_buffer_readout_work_fn(struct k_work *work)
 	uint8_t index = transfer_work->msg_index;
 	struct i2c_msg *msg = &transfer_work->msgs[index];
 
-	ret = mfd_sc18is604_read_buffer_signal(config->parent_dev,
-					       msg->buf, msg->len,
+	ret = mfd_sc18is604_read_buffer_signal(config->parent_dev, msg->buf, msg->len,
 					       &transfer_work->signal);
 	if (ret != 0) {
 		i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
@@ -289,21 +276,19 @@ static void i2c_sc18is604_buffer_readout_work_fn(struct k_work *work)
 
 static void i2c_sc18is604_finish_msg_work_fn(struct k_work *work)
 {
-	struct i2c_sc18is604_xfr_cb_work *transfer_work = CONTAINER_OF(work,
-			struct i2c_sc18is604_xfr_cb_work, work_finish_msg);
+	struct i2c_sc18is604_xfr_cb_work *transfer_work =
+		CONTAINER_OF(work, struct i2c_sc18is604_xfr_cb_work, work_finish_msg);
 	const struct device *dev = transfer_work->dev;
-	struct i2c_sc18is604_data * const data = dev->data;
+	struct i2c_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	int result = 0;
-	int signaled = await_signal(&transfer_work->signal,
-				    &result, K_NO_WAIT);
+	int signaled = await_signal(&transfer_work->signal, &result, K_NO_WAIT);
 
 	if (!signaled) {
 		ret = k_work_submit(work);
 		if (ret != 1 && ret != 0) {
-			i2c_sc18is604_transfer_cb_process_done(
-						transfer_work, -EIO);
+			i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
 			return;
 		}
 		return;
@@ -319,13 +304,11 @@ static void i2c_sc18is604_finish_msg_work_fn(struct k_work *work)
 	struct i2c_msg *msg = &transfer_work->msgs[index];
 
 	if ((msg->flags & I2C_MSG_READ) != I2C_MSG_READ) {
-		signaled = await_signal(&data->interrupt_signal,
-					&result, K_NO_WAIT);
+		signaled = await_signal(&data->interrupt_signal, &result, K_NO_WAIT);
 		if (!signaled) {
 			ret = k_work_submit(work);
 			if (ret != 1 && ret != 0) {
-				i2c_sc18is604_transfer_cb_process_done(
-							transfer_work, -EIO);
+				i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
 				return;
 			}
 			return;
@@ -336,8 +319,7 @@ static void i2c_sc18is604_finish_msg_work_fn(struct k_work *work)
 		 * signal).
 		 */
 		if (result != SC18IS604_I2C_STATUS_SUCCESS) {
-			i2c_sc18is604_transfer_cb_process_done(
-						transfer_work, -EIO);
+			i2c_sc18is604_transfer_cb_process_done(transfer_work, -EIO);
 			return;
 		}
 	}
@@ -358,22 +340,20 @@ static void i2c_sc18is604_finish_msg_work_fn(struct k_work *work)
 	}
 }
 
-int i2c_sc18is604_transfer_cb(const struct device *dev,
-			      struct i2c_msg *msgs, uint8_t num_msgs,
-			      uint16_t addr,
-			      i2c_callback_t cb, void *userdata)
+int i2c_sc18is604_transfer_cb(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			      uint16_t addr, i2c_callback_t cb, void *userdata)
 {
 	int ret = 0;
 
 	/* Create work item for tracking this transfer */
-	struct i2c_sc18is604_xfr_cb_work *transfer_work = k_calloc(1,
-				sizeof(struct i2c_sc18is604_xfr_cb_work));
+	struct i2c_sc18is604_xfr_cb_work *transfer_work =
+		k_calloc(1, sizeof(struct i2c_sc18is604_xfr_cb_work));
 
 	if (transfer_work == NULL) {
 		return -ENOMEM;
 	}
 
-	*transfer_work = (struct i2c_sc18is604_xfr_cb_work) {
+	*transfer_work = (struct i2c_sc18is604_xfr_cb_work){
 		.dev = dev,
 		.owns_lock = false,
 		.msg_index = 0,
@@ -383,12 +363,9 @@ int i2c_sc18is604_transfer_cb(const struct device *dev,
 		.cb = cb,
 		.userdata = userdata,
 	};
-	k_work_init(&transfer_work->work_init_msg,
-		    i2c_sc18is604_init_msg_work_fn);
-	k_work_init(&transfer_work->work_buffer_readout,
-		    i2c_sc18is604_buffer_readout_work_fn);
-	k_work_init(&transfer_work->work_finish_msg,
-		    i2c_sc18is604_finish_msg_work_fn);
+	k_work_init(&transfer_work->work_init_msg, i2c_sc18is604_init_msg_work_fn);
+	k_work_init(&transfer_work->work_buffer_readout, i2c_sc18is604_buffer_readout_work_fn);
+	k_work_init(&transfer_work->work_finish_msg, i2c_sc18is604_finish_msg_work_fn);
 	k_poll_signal_init(&transfer_work->signal);
 
 	ret = k_work_submit(&transfer_work->work_init_msg);

--- a/drivers/mfd/Kconfig.sc18is604
+++ b/drivers/mfd/Kconfig.sc18is604
@@ -22,16 +22,15 @@ config MFD_SC18IS604_ASYNC
 	default y if I2C_SC18IS604
 	default n
 	depends on POLL
-	depends on DYNAMIC_THREAD
 
 if MFD_SC18IS604_ASYNC
 
-config MFD_SC18IS604_WORKQUEUE_STACK_SIZE
-	int
-	default 512
+	config MFD_SC18IS604_WORKQUEUE_STACK_SIZE
+		int
+		default 512
 
-config HEAP_MEM_POOL_ADD_SIZE_MFD_SC18IS604
-	int
-	default 256
+	config HEAP_MEM_POOL_ADD_SIZE_MFD_SC18IS604
+		int
+		default 256
 
 endif # MFD_SC18IS604_ASYNC

--- a/drivers/mfd/mfd_sc18is604.h
+++ b/drivers/mfd/mfd_sc18is604.h
@@ -25,22 +25,20 @@ extern "C" {
  * Values in Hz, intentionally to be comparable with the spi-max-frequency
  * property from DT bindings in spi-device.yaml.
  */
-#define MFD_SC18IS604_SPI_HZ_MIN		100000
-#define MFD_SC18IS604_SPI_HZ_MAX		1200000
+#define MFD_SC18IS604_SPI_HZ_MIN 100000
+#define MFD_SC18IS604_SPI_HZ_MAX 1200000
 
-#define MFD_SC18IS604_SPI_DELAY_USEC		8 /* between two SPI bytes */
-#define MFD_SC18IS604_RESET_SETUP_USEC		1 /* >= 125ns acceptance time */
-#define MFD_SC18IS604_RESET_TIME_USEC		500
+#define MFD_SC18IS604_SPI_DELAY_USEC   8 /* between two SPI bytes */
+#define MFD_SC18IS604_RESET_SETUP_USEC 1 /* >= 125ns acceptance time */
+#define MFD_SC18IS604_RESET_TIME_USEC  500
 
 /* timeout for about two times a maximum command (three byte) at 100kHz */
-#define MFD_SC18IS604_CMD_MAX_TOUT_USEC		200
+#define MFD_SC18IS604_CMD_MAX_TOUT_USEC 200
 
 /* expected chip in version string */
-#define MFD_SC18IS604_VERSION_CHIP		"SC18IS604"
-BUILD_ASSERT(
-	ARRAY_SIZE(MFD_SC18IS604_VERSION_CHIP) <= SC18IS604_VERSION_STRING_SIZE,
-	"Chip name too long"
-);
+#define MFD_SC18IS604_VERSION_CHIP "SC18IS604"
+BUILD_ASSERT(ARRAY_SIZE(MFD_SC18IS604_VERSION_CHIP) <= SC18IS604_VERSION_STRING_SIZE,
+	     "Chip name too long");
 
 /**
  * @brief SC18IM604 MFD configuration data

--- a/drivers/mfd/mfd_sc18is604_transfer.c
+++ b/drivers/mfd/mfd_sc18is604_transfer.c
@@ -14,12 +14,10 @@
 
 #include "mfd_sc18is604.h"
 
-int mfd_sc18is604_transfer(const struct device *dev,
-			   uint8_t *cmd, size_t cmd_len,
-			   uint8_t *tx_data, size_t tx_len,
-			   uint8_t *rx_data, size_t rx_len)
+int mfd_sc18is604_transfer(const struct device *dev, uint8_t *cmd, size_t cmd_len, uint8_t *tx_data,
+			   size_t tx_len, uint8_t *rx_data, size_t rx_len)
 {
-	const struct mfd_sc18is604_config * const config = dev->config;
+	const struct mfd_sc18is604_config *const config = dev->config;
 	int ret = 0;
 
 	/*
@@ -35,10 +33,7 @@ int mfd_sc18is604_transfer(const struct device *dev,
 		.len = 1,
 	};
 
-	const struct spi_buf_set buf_set = {
-		.buffers = &buffer,
-		.count = 1
-	};
+	const struct spi_buf_set buf_set = {.buffers = &buffer, .count = 1};
 
 	/* Write command sequence */
 	if (cmd != NULL) {
@@ -92,29 +87,23 @@ end:
 	return ret;
 }
 
-int mfd_sc18is604_read_register(const struct device *dev,
-				uint8_t reg, uint8_t *val)
+int mfd_sc18is604_read_register(const struct device *dev, uint8_t reg, uint8_t *val)
 {
 	uint8_t cmd[] = {SC18IS604_CMD_READ_REGISTER, reg};
 
-	return mfd_sc18is604_transfer(dev, cmd, ARRAY_SIZE(cmd),
-					   NULL, 0, val, 1);
+	return mfd_sc18is604_transfer(dev, cmd, ARRAY_SIZE(cmd), NULL, 0, val, 1);
 }
 
-int mfd_sc18is604_write_register(const struct device *dev,
-				 uint8_t reg, uint8_t val)
+int mfd_sc18is604_write_register(const struct device *dev, uint8_t reg, uint8_t val)
 {
 	uint8_t cmd[] = {SC18IS604_CMD_WRITE_REGISTER, reg};
 
-	return mfd_sc18is604_transfer(dev, cmd, ARRAY_SIZE(cmd),
-					   &val, 1, NULL, 0);
+	return mfd_sc18is604_transfer(dev, cmd, ARRAY_SIZE(cmd), &val, 1, NULL, 0);
 }
 
-int mfd_sc18is604_read_buffer(const struct device *dev,
-			      uint8_t *data, size_t len)
+int mfd_sc18is604_read_buffer(const struct device *dev, uint8_t *data, size_t len)
 {
 	uint8_t cmd[] = {SC18IS604_CMD_READ_BUFFER};
 
-	return mfd_sc18is604_transfer(dev, cmd, ARRAY_SIZE(cmd),
-					   NULL, 0, data, len);
+	return mfd_sc18is604_transfer(dev, cmd, ARRAY_SIZE(cmd), NULL, 0, data, len);
 }

--- a/drivers/mfd/mfd_sc18is604_transfer_async.c
+++ b/drivers/mfd/mfd_sc18is604_transfer_async.c
@@ -46,18 +46,15 @@ struct mfd_sc18is604_transfer_work {
 static void mfd_sc18is604_transfer_work_fn(struct k_work *work)
 {
 	/* Access bundled data */
-	struct mfd_sc18is604_transfer_work *transfer_work = CONTAINER_OF(work,
-				struct mfd_sc18is604_transfer_work, work);
+	struct mfd_sc18is604_transfer_work *transfer_work =
+		CONTAINER_OF(work, struct mfd_sc18is604_transfer_work, work);
 	const struct device *dev = transfer_work->dev;
 	int ret = 0;
 
 	/* Call blocking transfer */
-	ret = mfd_sc18is604_transfer(dev, transfer_work->cmd,
-					  transfer_work->cmd_len,
-					  transfer_work->tx_data,
-					  transfer_work->tx_len,
-					  transfer_work->rx_data,
-					  transfer_work->rx_len);
+	ret = mfd_sc18is604_transfer(dev, transfer_work->cmd, transfer_work->cmd_len,
+				     transfer_work->tx_data, transfer_work->tx_len,
+				     transfer_work->rx_data, transfer_work->rx_len);
 
 	/* Report result through signal */
 	k_poll_signal_raise(transfer_work->signal, ret);
@@ -67,23 +64,21 @@ static void mfd_sc18is604_transfer_work_fn(struct k_work *work)
 	k_free(transfer_work);
 }
 
-int mfd_sc18is604_transfer_signal(const struct device *dev,
-				  uint8_t *cmd, size_t cmd_len,
-				  uint8_t *tx_data, size_t tx_len,
-				  uint8_t *rx_data, size_t rx_len,
+int mfd_sc18is604_transfer_signal(const struct device *dev, uint8_t *cmd, size_t cmd_len,
+				  uint8_t *tx_data, size_t tx_len, uint8_t *rx_data, size_t rx_len,
 				  struct k_poll_signal *signal)
 {
-	struct mfd_sc18is604_data * const data = dev->data;
+	struct mfd_sc18is604_data *const data = dev->data;
 	int ret = 0;
 
 	/* Create work item to manage transfers */
-	struct mfd_sc18is604_transfer_work *transfer_work = k_malloc(
-			sizeof(struct mfd_sc18is604_transfer_work));
+	struct mfd_sc18is604_transfer_work *transfer_work =
+		k_malloc(sizeof(struct mfd_sc18is604_transfer_work));
 	if (transfer_work == NULL) {
 		return -ENOMEM;
 	}
 
-	*transfer_work = (struct mfd_sc18is604_transfer_work) {
+	*transfer_work = (struct mfd_sc18is604_transfer_work){
 		.dev = dev,
 		.cmd_len = cmd_len,
 		.tx_data = tx_data,
@@ -119,22 +114,18 @@ int mfd_sc18is604_transfer_signal(const struct device *dev,
 	return 0;
 }
 
-int mfd_sc18is604_read_register_signal(const struct device *dev,
-				       uint8_t reg, uint8_t *val,
+int mfd_sc18is604_read_register_signal(const struct device *dev, uint8_t reg, uint8_t *val,
 				       struct k_poll_signal *signal)
 {
-	uint8_t cmd[] = { SC18IS604_CMD_READ_REGISTER, reg };
+	uint8_t cmd[] = {SC18IS604_CMD_READ_REGISTER, reg};
 
-	return mfd_sc18is604_transfer_signal(dev, cmd, ARRAY_SIZE(cmd),
-						  NULL, 0, val, 1, signal);
+	return mfd_sc18is604_transfer_signal(dev, cmd, ARRAY_SIZE(cmd), NULL, 0, val, 1, signal);
 }
 
-int mfd_sc18is604_read_buffer_signal(const struct device *dev,
-			      uint8_t *data, size_t len,
-			      struct k_poll_signal *signal)
+int mfd_sc18is604_read_buffer_signal(const struct device *dev, uint8_t *data, size_t len,
+				     struct k_poll_signal *signal)
 {
-	uint8_t cmd[] = { SC18IS604_CMD_READ_BUFFER };
+	uint8_t cmd[] = {SC18IS604_CMD_READ_BUFFER};
 
-	return mfd_sc18is604_transfer_signal(dev, cmd, ARRAY_SIZE(cmd),
-						  NULL, 0, data, len, signal);
+	return mfd_sc18is604_transfer_signal(dev, cmd, ARRAY_SIZE(cmd), NULL, 0, data, len, signal);
 }

--- a/include/zephyr/drivers/mfd/sc18is604.h
+++ b/include/zephyr/drivers/mfd/sc18is604.h
@@ -105,14 +105,14 @@ int mfd_sc18is604_transfer(const struct device *dev,
  *
  * @param dev An SC18IS604 MFD device.
  * @param reg Register address to write to.
- * @param val Value to write into the register.
+ * @param value Value to write into the register.
  *
  * @return A value from mfd_sc18is604_transfer().
  */
 int mfd_sc18is604_read_register(const struct device *dev,
 				uint8_t reg, uint8_t *val);
 
-#define READ_SC18IS604_REG(dev, reg, val)                                    \
+#define READ_SC18IS604_REG(dev, reg, val) \
 	mfd_sc18is604_read_register((dev), SC18IS604_REG_##reg, (val));
 
 /**
@@ -120,14 +120,14 @@ int mfd_sc18is604_read_register(const struct device *dev,
  *
  * @param dev An SC18IS604 MFD device.
  * @param reg Register address to read from.
- * @param[out] val Value read from the register.
+ * @param[out] value Value read from the register.
  *
  * @return A value from mfd_sc18is604_transfer().
  */
 int mfd_sc18is604_write_register(const struct device *dev,
 				 uint8_t reg, uint8_t val);
 
-#define WRITE_SC18IS604_REG(dev, reg, val)                                   \
+#define WRITE_SC18IS604_REG(dev, reg, val) \
 	mfd_sc18is604_write_register((dev), SC18IS604_REG_##reg, (val));
 
 /**
@@ -184,7 +184,7 @@ int mfd_sc18is604_claim(const struct device *dev, k_timeout_t timeout);
  */
 void mfd_sc18is604_release(const struct device *dev);
 
-#ifdef CONFIG_MFD_SC18IS604_ASYNC
+#if defined(CONFIG_MFD_SC18IS604_ASYNC)
 
 /**
  * @brief Asynchronously transfer data to and from an SC18IS604 device. This is
@@ -219,8 +219,8 @@ int mfd_sc18is604_transfer_signal(const struct device *dev,
  * @param reg Register address to read from.
  * @param[out] value Value read from the register. Pointer must remain valid
  *                   until the transfer is complete.
- * @param signal Signal that will be raised on transfer completion. Pointer
- *               must remain valid until the transfer is complete.
+ * @param signal Signal that will be raised on transfer completion. Pointer must
+ *               remain valid until the transfer is complete.
  *
  * @return A value from mfd_sc18is604_transfer_signal().
  */
@@ -228,9 +228,8 @@ int mfd_sc18is604_read_register_signal(const struct device *dev,
 				       uint8_t reg, uint8_t *val,
 				       struct k_poll_signal *signal);
 
-#define READ_SC18IS604_REG_SIGNAL(dev, reg, val, signal)                     \
-	mfd_sc18is604_read_register_signal((dev), SC18IS604_REG_##reg,       \
-						  (val), (signal));
+#define READ_SC18IS604_REG_SIGNAL(dev, reg, val, signal) \
+	mfd_sc18is604_read_register_signal((dev), SC18IS604_REG_##reg, (val), (signal));
 
 /**
  * @brief Read data from the internal buffer of an SC18IS604 asynchronously.
@@ -239,16 +238,16 @@ int mfd_sc18is604_read_register_signal(const struct device *dev,
  * @param[out] data Data read from the buffer. Pointer must remain valid until
  *                  the transfer is complete.
  * @param len Number of bytes to read from the buffer.
- * @param signal Signal that will be raised on transfer completion. Pointer
- *               must remain valid until the transfer is complete.
+ * @param signal Signal that will be raised on transfer completion. Pointer must
+ *               remain valid until the transfer is complete.
  *
  * @return A value from mfd_sc18is604_transfer().
  */
 int mfd_sc18is604_read_buffer_signal(const struct device *dev,
-				     uint8_t *data, size_t len,
-				     struct k_poll_signal *signal);
+			      uint8_t *data, size_t len,
+			      struct k_poll_signal *signal);
 
-#endif /* CONFIG_MFD_SC18IS604_ASYNC */
+#endif /* defined(CONFIG_MFD_SC18IS604_ASYNC) */
 
 /** @} */
 


### PR DESCRIPTION
Adds several improvements and bugfixes for SC18IS604 type I2C controllers:

- Use static thread allocation instead of dynamic threads
- Use driver instance specific workqueue instead of the system workqueue to avoid deadlocks
- Enable device power management

The large diff is mostly caused by also running clang-format on the drivers to bring them in line with the rest of the tree. I recommend skipping the first commit on review to see only the substantial changes.