### PR TITLE
loopback_test: tiac_magpie: reduce fast transfer clock

### DIFF
--- a/boards/shields/loopback_test/boards/magpie_f777ni.overlay
+++ b/boards/shields/loopback_test/boards/magpie_f777ni.overlay
@@ -1,8 +1,18 @@
 /*
- * Copyright (c) 2021 TiaC Systems
+ * Copyright (c) 2021-2025 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <freq.h>
+
+&tmph_spi1_fast {
+	/*
+	 * Reduce fast transfer clock to max. 15 MHz,
+	 * because of missing DMA setup.
+	 */
+	spi-max-frequency = <DT_FREQ_M(15)>;
+}; // tmph_spi1
 
 &tmph_spi2 {
 	status = "disabled";	/* conflicts with tmph_i2c2 */

--- a/boards/shields/loopback_test/loopback_test_tmph.overlay
+++ b/boards/shields/loopback_test/loopback_test_tmph.overlay
@@ -1,8 +1,10 @@
 /*
- * Copyright (c) 2021-2022 TiaC Systems
+ * Copyright (c) 2021-2025 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <freq.h>
 
 / {
 	gpio_basic_api_0 {
@@ -31,16 +33,16 @@
 &tmph_spi1 {
 	status = "okay";
 
-	slow@0 {
+	tmph_spi1_slow: slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;
-		spi-max-frequency = <500000>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
 	};
 
-	fast@0 {
+	tmph_spi1_fast: fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;
-		spi-max-frequency = <50000000>;
+		spi-max-frequency = <DT_FREQ_M(50)>;
 	};
 }; // tmph_spi1
 

--- a/doc/bridle/releases/release-notes-4.2.0.rst
+++ b/doc/bridle/releases/release-notes-4.2.0.rst
@@ -225,6 +225,7 @@ Issue Related Items
 
 These GitHub issues were addressed since project bootstrapping:
 
+* :github:`325` - [BUG] SPI Loopback test suit files on TiaC Magpie F777NI
 * :github:`320` - [BUG] CMSIS_6 module required by the ARM port for Cortex-M
 * :github:`317` - [BUG] Rename Kconfig option ``SCHED_DUMB`` and ``WAITQ_DUMB``
 * :github:`316` - [BUG] Remove Kconfig option ``ETH_STM32_HAL_MII`` and ``ETH_STM32_HAL_PHY_ADDRESS``


### PR DESCRIPTION
Reduce fast transfer clock to max. 15 MHz, because of missing DMA setup.

As long as the board has no DMA acceleration enabled for SPI transfers the original intended clock of 50 MHz will be to fast for the new Zephyr upstream timing testcase. This would be lead to a "Very high latency" failure, the transfer takes way longer than it should.

fixes #325 