### PR TITLE
tests: fix platfrom_exclude: for HiFive1 Rev B

### DIFF
--- a/tests/shields/grove_btn/dts_bindings/testcase.yaml
+++ b/tests/shields/grove_btn/dts_bindings/testcase.yaml
@@ -406,7 +406,7 @@ tests:
     platform_exclude:
       - frdm_kw41z
       - hifive1
-      - hifive1@B
+      - hifive1_revb
   grove.base.v2.grove_btn.gpio.d14.inv:
     depends_on: arduino_gpio
     filter: dt_nodelabel_enabled("grove_a0_header") and
@@ -415,7 +415,7 @@ tests:
     platform_exclude:
       - frdm_kw41z
       - hifive1
-      - hifive1@B
+      - hifive1_revb
   grove.base.v1.grove_btn.gpio.d14:
     depends_on: arduino_gpio
     filter: dt_nodelabel_enabled("grove_a0_header") and
@@ -424,7 +424,7 @@ tests:
     platform_exclude:
       - frdm_kw41z
       - hifive1
-      - hifive1@B
+      - hifive1_revb
   grove.base.v1.grove_btn.gpio.d14.inv:
     depends_on: arduino_gpio
     filter: dt_nodelabel_enabled("grove_a0_header") and
@@ -433,7 +433,7 @@ tests:
     platform_exclude:
       - frdm_kw41z
       - hifive1
-      - hifive1@B
+      - hifive1_revb
   grove.base.v2.grove_btn.gpio.d15:
     depends_on: arduino_gpio
     filter: ( dt_nodelabel_enabled("grove_a1_header") or

--- a/tests/shields/grove_led/dts_bindings/testcase.yaml
+++ b/tests/shields/grove_led/dts_bindings/testcase.yaml
@@ -235,7 +235,7 @@ tests:
     platform_exclude:
       - frdm_kw41z
       - hifive1
-      - hifive1@B
+      - hifive1_revb
   grove.base.v1.grove_led.gpio.d14:
     depends_on: arduino_gpio
     filter: dt_nodelabel_enabled("grove_a0_header") and
@@ -244,7 +244,7 @@ tests:
     platform_exclude:
       - frdm_kw41z
       - hifive1
-      - hifive1@B
+      - hifive1_revb
   grove.base.v2.grove_led.gpio.d15:
     depends_on: arduino_gpio
     filter: ( dt_nodelabel_enabled("grove_a1_header") or


### PR DESCRIPTION
The HiFive1 Rev B is no longer a board revision, as it is powered by a completely different SoC (Risc-V FE310, G002 vs. G000) and therefore requires a separate HWMv2 board name.