### PR TITLE
Nix Flake Maintenance

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743964447,
-        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {
@@ -92,11 +92,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1743438845,
-        "narHash": "sha256-1GSaoubGtvsLRwoYwHjeKYq40tLwvuFFVhGrG8J9Oek=",
+        "lastModified": 1746540146,
+        "narHash": "sha256-QxdHGNpbicIrw5t6U3x+ZxeY/7IEJ6lYbvsjXmcxFIM=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "8063ec98edc459571d042a640b1c5e334ecfca1e",
+        "rev": "e09c10c24ebb955125fda449939bfba664c467fd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "cache-nix-action": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1746350578,
+        "narHash": "sha256-66auSJUldF+QLnMZEvOR9y9+P6doadeHmYl5UDFqVic=",
+        "owner": "nix-community",
+        "repo": "cache-nix-action",
+        "rev": "76f6697d63b7378f7161d52f3d81784130ecd90d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "cache-nix-action",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -128,17 +144,19 @@
     },
     "python-deps": {
       "inputs": {
+        "cache-nix-action": "cache-nix-action",
         "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1744108749,
-        "narHash": "sha256-oHXHo40mCjzKDZ7z612Nxy+GZ6lASann2C0b6IF/izw=",
+        "lastModified": 1749814343,
+        "narHash": "sha256-a8hlqXk3cCdSEHCzPJCRe0sLCbMlNsCT0uTWiy970+M=",
         "owner": "Irockasingranite",
         "repo": "bridle-python-deps",
-        "rev": "64c84420b216310ec545134ac2cec0b65108bd5d",
+        "rev": "5b8412a02bd485972603d1c1948801780ea3e070",
         "type": "github"
       },
       "original": {
@@ -175,6 +193,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,12 @@
     (flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            inputs.python-deps.overlays.default
+          ];
+        };
 
         west2nix = callPackage inputs.west2nix.lib.mkWest2nix { };
 

--- a/python.nix
+++ b/python.nix
@@ -45,11 +45,6 @@ let
         sphinx-lint
         sphobjinv
         ;
-
-      # WORKAROUND for missing defusedxml in nativeCheckInputs of sphinx-sitemap derivation.
-      sphinx-sitemap = prev.sphinx-sitemap.overrideAttrs (old: {
-        pytestCheckPhase = ''true'';
-      });
     };
   };
 

--- a/python.nix
+++ b/python.nix
@@ -1,50 +1,27 @@
 {
-  python3,
+  pkgs,
+  lib,
   zephyr,
   bridle,
   python-deps,
   pyproject-nix,
-  clang-tools,
-  gitlint,
-  gcovr,
-  mcuboot-imgtool,
-  ruff,
-  lib,
 }:
 
 let
 
   # Create a python whose `withPackages` knows about some extra stuff we need
-  python = python3.override {
+  python = pkgs.python3.override {
     self = python;
     packageOverrides = final: prev: {
-      # HACK: Zephyr uses pypi to install non-Python deps
-      clang-format = clang-tools;
+      # Some packages zephyr likes to install using pypi are provided as toplevel packages in
+      # nixpkgs. Adding them to this package set makes sure they can be pulled into the build/dev
+      # environment by being referenced in a requirements.txt
 
-      # gcovr provided as toplevel package
-      inherit gcovr;
+      inherit (pkgs) gcovr gitlint ruff;
+      clang-format = pkgs.clang-tools;
+      imgtool = pkgs.mcuboot-imgtool;
 
-      # gitlint provided as toplevel package
-      inherit gitlint;
-
-      # imgtool provided as toplevel package
-      imgtool = mcuboot-imgtool;
-
-      # ruff provided as a toplevel package
-      inherit ruff;
-
-      # Extra python packages that aren't in nixpkgs
-      inherit (python-deps)
-        doxmlparser
-        nrf-regtool
-        pykitinfo
-        pymcuprog
-        sphinx-tsn-theme
-        sphinxcontrib-svg2pdfconverter
-        sphinx-csv-filter
-        sphinx-lint
-        sphobjinv
-        ;
+      inherit (python-deps) nrf-regtool sphinx-lint;
     };
   };
 

--- a/west2nix.toml
+++ b/west2nix.toml
@@ -14,7 +14,7 @@ hash = "sha256-2GXfsdjqouRrOKJg+1dCTZikS4oi8WPoe6xbAKU+Wv8="
 [[manifest.projects]]
 name = "zephyr"
 url = "https://github.com/tiacsys/zephyr"
-revision = "2f39d26922db45264368f876ca7e35a152bd2831"
+revision = "56161537ac3aa20d71925b4cd59231615e655eb0"
 clone-depth = 5000
 west-commands = "scripts/west-commands.yml"
 
@@ -22,7 +22,7 @@ west-commands = "scripts/west-commands.yml"
 west-commands-path = "scripts/west_commands"
 
 [manifest.projects.nix]
-hash = "sha256-ydSRd/8MoZhHo+gL5N6Z/zaU6XvnGMyubPMqs2l1H18="
+hash = "sha256-oC28viN3s9O+BXQUONU5dDxuS3WZRLF7sYvZ12Qhfgs="
 
 [[manifest.projects]]
 name = "canopennode"
@@ -57,12 +57,12 @@ hash = "sha256-TVVfNZyRrval2wvvu9DSIxhB2OiyFPSZRX2lsdcFcoA="
 [[manifest.projects]]
 name = "tf-m-tests"
 url = "https://github.com/zephyrproject-rtos/tf-m-tests"
-revision = "502ea90105ee18f20c78f710e2ba2ded0fc0756e"
+revision = "c712761dd5391bf3f38033643d28a736cae89a19"
 path = "modules/tee/tf-m/tf-m-tests"
 groups = ["optional"]
 
 [manifest.projects.nix]
-hash = "sha256-rec6QftsVRNYv4xdGjYEQ1HJerr3S6IMHMiJ9lD8UE8="
+hash = "sha256-KbkVSwyw/g8MzTrwHjraRg5yQ3AaTZYW67H0AJPUeGU="
 
 [[manifest.projects]]
 name = "acpica"
@@ -76,12 +76,22 @@ hash = "sha256-DwE7etw6DqWHb/NvGwep19RYsVmA/CBxvTnFVmqf2Io="
 [[manifest.projects]]
 name = "cmsis"
 url = "https://github.com/zephyrproject-rtos/cmsis"
-revision = "d1b8b20b6278615b00e136374540eb1c00dcabe7"
+revision = "512cc7e895e8491696b61f7ba8066b4a182569b8"
 path = "modules/hal/cmsis"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-41c6ugwL9D5aQHh6lLCTf2iJP0yAn8bVXOsVUsguuQg="
+hash = "sha256-IR4Za8TuYY7nkqK57xUJ2uWnCp7wB9B4/ZjhalLhCUU="
+
+[[manifest.projects]]
+name = "cmsis_6"
+url = "https://github.com/zephyrproject-rtos/CMSIS_6"
+revision = "6dd50439a9b83398ff2ae1376eef0a2a0b95913b"
+path = "modules/hal/cmsis_6"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-NaQ/2ko3xDqd5sPFAV/QB5WbHKscx1x0UB4WsYB5ppU="
 
 [[manifest.projects]]
 name = "edtt"
@@ -106,53 +116,53 @@ hash = "sha256-pHr2E+ty2fEMrGpCBa/yVQpNEgBFV3brNmGXOZBPc5g="
 [[manifest.projects]]
 name = "hal_adi"
 url = "https://github.com/zephyrproject-rtos/hal_adi"
-revision = "633fcecf3717aaa22079cf6121627a879f24df51"
+revision = "f8f65473168a4e9f71f20c0c5387f6b80fe54cf3"
 path = "modules/hal/adi"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-NK9m+xHyfjlkfK+R5iuAS8F3Ga/mfdFaHJagTG47ydA="
-
-[[manifest.projects]]
-name = "hal_altera"
-url = "https://github.com/zephyrproject-rtos/hal_altera"
-revision = "4fe4df959d4593ce66e676aeba0b57f546dba0fe"
-path = "modules/hal/altera"
-groups = ["hal"]
-
-[manifest.projects.nix]
-hash = "sha256-KM89pVzBbYatHtOtDq9EtBGpMp6rYcrKrXWHExKeqYM="
+hash = "sha256-C1hg0xTg/kX1m++8Pr0VXJyfvnbYR/3+4qmkkamwEas="
 
 [[manifest.projects]]
 name = "hal_ambiq"
 url = "https://github.com/zephyrproject-rtos/hal_ambiq"
-revision = "87a188b91aca22ce3ce7deb4a1cbf7780d784673"
+revision = "f46941f3427bbc05d893a601660e6e3cffe9e29d"
 path = "modules/hal/ambiq"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-hHiAmu871w81lA8KecTG4YI36hsD+SkLb9PNfCcNPCw="
+hash = "sha256-wDOkEnBHNLtcd2GQKyouTgB4yiqShT/cCvBTF4MVNow="
 
 [[manifest.projects]]
 name = "hal_atmel"
 url = "https://github.com/zephyrproject-rtos/hal_atmel"
-revision = "da767444cce3c1d9ccd6b8a35fd7c67dc82d489c"
+revision = "ca7e4c6920f44b9d677ed5995ffa169f18a54cdf"
 path = "modules/hal/atmel"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-IbXaB+gB4FpSTX4uW6vt7LUMmokv3HWpD9TuEXpwRCo="
+hash = "sha256-VO7zdFW6qaYgS3I0AjNOv7LYQiR8KuH91GeLjxMr/4s="
+
+[[manifest.projects]]
+name = "hal_bouffalolab"
+url = "https://github.com/zephyrproject-rtos/hal_bouffalolab"
+revision = "5811738e2be348f30dc97d78280f2735d5d14084"
+path = "modules/hal/bouffalolab"
+groups = ["hal"]
+
+[manifest.projects.nix]
+hash = "sha256-uFOEHWBtMj3rm9IOmURXkC77xL7SmOLfi8vZxyKJVLg="
 
 [[manifest.projects]]
 name = "hal_espressif"
 url = "https://github.com/zephyrproject-rtos/hal_espressif"
-revision = "202c59552dc98e5cd02386313e1977ecb17a131f"
+revision = "82c93ea7f5e90f7e028dc59bfa351d774eb66f37"
 path = "modules/hal/espressif"
 west-commands = "west/west-commands.yml"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-qfDTDcN3VLbtADH+IuLnI4t49nWWdl2Ka+x52ywTBFQ="
+hash = "sha256-/vtTze0+WkHCqLTZxD3QXSiOTGeJ8LeVyChznnEPIKs="
 
 [[manifest.projects]]
 name = "hal_ethos_u"
@@ -177,62 +187,62 @@ hash = "sha256-Cgcc+7tJy0ryQG4ynrlv7OmNe3OW2kMx1mStGROgA5o="
 [[manifest.projects]]
 name = "hal_infineon"
 url = "https://github.com/zephyrproject-rtos/hal_infineon"
-revision = "468e955eb49b8a731474ff194ca17b6e6a08c2d9"
+revision = "0fe4f3aee9c8f7002996a94d91299b2c28d6a8fa"
 path = "modules/hal/infineon"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-7eJERntmXLrJF4N2q0kcrEdwjUQGkH/0d10sOc8JQag="
+hash = "sha256-ULw4BzNOjqr6ZCwugbtG7hZQh4InPcpTb7MIOvJaGW4="
 
 [[manifest.projects]]
 name = "hal_intel"
 url = "https://github.com/zephyrproject-rtos/hal_intel"
-revision = "0355bb816263c54eed23c7781034447af5d8200c"
+revision = "0447cd22e74d7ca243653f21cfd6e38c016630c6"
 path = "modules/hal/intel"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-yG/qsNQm8WBhW0NwUTYK6UAw/8FdbZrH435advrQ6LY="
+hash = "sha256-HEgoY3jABEZRGL1GCT2CiCroZduaZTuiVyYO4fqozU0="
 
 [[manifest.projects]]
 name = "hal_microchip"
 url = "https://github.com/zephyrproject-rtos/hal_microchip"
-revision = "fa2431a906ffb560160d40739d7cf04169551103"
+revision = "4b74f4081342423badcf758278bbc0582ca8735d"
 path = "modules/hal/microchip"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-T6RjUD1iNO0yP6HY6FhvXIhmB3mCkXZYENxlxr4d3zY="
+hash = "sha256-Q5aaXGi0yUzqdt1XpkoqDRlmdT7ruFa2HPx97Cpd0k0="
 
 [[manifest.projects]]
 name = "hal_nordic"
 url = "https://github.com/zephyrproject-rtos/hal_nordic"
-revision = "37ca068d7b013fb65a2acc9306bffa48a3e72839"
+revision = "6e39d4f2b078afaebdb84875089486152fcacb9c"
 path = "modules/hal/nordic"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-2Johs7F9W4tspOT+6fRz1kNFN+SKSjaWx2i9tl10Hlw="
+hash = "sha256-cYjpaUqfbGOmZVoY4gecKLxBw0MfoDZHkZbGz9mpsZ4="
 
 [[manifest.projects]]
 name = "hal_nuvoton"
 url = "https://github.com/zephyrproject-rtos/hal_nuvoton"
-revision = "466c3eed9c98453fb23953bf0e0427fea01924be"
+revision = "be1042dc8a96ebe9ea4c5d714f07c617539106d6"
 path = "modules/hal/nuvoton"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-0T+E4JUtSiWsypVPYnlRvDNr1otXRzLDCvx2TDQKS1Y="
+hash = "sha256-fIeEx2SzZl9lrx/FoxBO3XsqdbqjRZAzJA9YBho6cK0="
 
 [[manifest.projects]]
 name = "hal_nxp"
 url = "https://github.com/zephyrproject-rtos/hal_nxp"
-revision = "9dc7449014a7380355612453b31be479cb3a6833"
+revision = "ad531e7b9980b171f90c651340bb1bb6cc2c6d51"
 path = "modules/hal/nxp"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-1QkOxoiMMUSPqae9g3O1fuIfGfoAdFRmagkJPW00Cww="
+hash = "sha256-QemS/7C4caLxgCwrf3X9lL/7d7OYrN4mcXn39kLQraE="
 
 [[manifest.projects]]
 name = "hal_openisa"
@@ -257,12 +267,12 @@ hash = "sha256-EFeySS+Kz7RecJ7it5CVAdP0y9m2gCCGl0Pu6l21+TQ="
 [[manifest.projects]]
 name = "hal_renesas"
 url = "https://github.com/zephyrproject-rtos/hal_renesas"
-revision = "3204903bdc5eda6869a40363560a69369c8d0e22"
+revision = "9b99067e29a1b44b53192c2c797db330f5703462"
 path = "modules/hal/renesas"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-fPUNDOYNGtkOg4WIEAlYOdTKJ4e3dgG6NA7zTvp3j2k="
+hash = "sha256-+QPLx1eplSQgtI6WSEzqCNC6/yn1V4o+A1m6uAFNZBE="
 
 [[manifest.projects]]
 name = "hal_rpi_pico"
@@ -277,32 +287,32 @@ hash = "sha256-jpEq/h/ec3cCH0ZZK4OTs+zx9V+g4Sg05HF5uDbwmI8="
 [[manifest.projects]]
 name = "hal_silabs"
 url = "https://github.com/zephyrproject-rtos/hal_silabs"
-revision = "8a173e9e566a396a19d18da4661cb54ce098f268"
+revision = "411072b67f564eb6ebceadbf9ffb1bb1ccdc7e73"
 path = "modules/hal/silabs"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-jEKFsArf3anoIxxYGQW3pi5JRu9D7HZLaP608mfwvW8="
+hash = "sha256-93UWICiIExXvHgKt289kZkrO6l8JtUoDT40N08fdwIE="
 
 [[manifest.projects]]
 name = "hal_st"
 url = "https://github.com/zephyrproject-rtos/hal_st"
-revision = "05fd4533730a9aea845261c5d24ed9832a6f0b6e"
+revision = "9f81b4427e955885398805b7bca0da3a8cd9109c"
 path = "modules/hal/st"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-0YFr1wSw76cD/c9WSyWxkOoRZlt1fL1LyJnIcZXhK6I="
+hash = "sha256-kpV0PCBd96ZbmKoLZtjrd0JovJK3++w56JdY0u7FP0Q="
 
 [[manifest.projects]]
 name = "hal_stm32"
 url = "https://github.com/zephyrproject-rtos/hal_stm32"
-revision = "55043bcc35fffa3b4a8c75a696d932b5020aad09"
+revision = "90f56420db7b2567675f623af09c474eae410814"
 path = "modules/hal/stm32"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-oc3NNoytfbVP70aN0WTjFOzOlTcpMWmJESsbZ8khhYk="
+hash = "sha256-dPVqLKVJWDHI0lsbZ1SoWVK6+UntLPPW81JRu7eZU8U="
 
 [[manifest.projects]]
 name = "hal_tdk"
@@ -327,12 +337,12 @@ hash = "sha256-6KopXpZXOK7v5AEbLPHUuxWya0eXTvDcDRDzqlejzoo="
 [[manifest.projects]]
 name = "hal_ti"
 url = "https://github.com/zephyrproject-rtos/hal_ti"
-revision = "258652a3ac5d7df68ba8df20e4705c3bd98ede38"
+revision = "bc8e7b99bb668cc51a3aa384448a48c48a33f8e2"
 path = "modules/hal/ti"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-OfhcwKUXNeWV+EWLnhEmhbqMktdI0pcMckP5Oy8brYQ="
+hash = "sha256-VVw9QbT3wrlhjQJa8m/eEn/7jY1iliVNvAMdlEwB/Aw="
 
 [[manifest.projects]]
 name = "hal_wurthelektronik"
@@ -347,12 +357,12 @@ hash = "sha256-Xf/xazKK3ttGV7hdvUQanust2AUGjDyt62h1yl1Sc7A="
 [[manifest.projects]]
 name = "hal_xtensa"
 url = "https://github.com/zephyrproject-rtos/hal_xtensa"
-revision = "baa56aa3e119b5aae43d16f9b2d2c8112e052871"
+revision = "b38620c7cc61e349e192ed86a54940a5cd0636b7"
 path = "modules/hal/xtensa"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-GSSznCIBNt9y/MG4UGa0U9gn/oOr8C9K35WY1vccXas="
+hash = "sha256-T2XCyXF3hGy9spIMAPebsoTwl4WkzJFZZMHy2KDCYq8="
 
 [[manifest.projects]]
 name = "liblc3"
@@ -366,22 +376,22 @@ hash = "sha256-OWuj68+YztIh/dPvwqjW7ch7Ph3aiEIDvO9rMkVIrQ8="
 [[manifest.projects]]
 name = "libmetal"
 url = "https://github.com/zephyrproject-rtos/libmetal"
-revision = "3e8781aae9d7285203118c05bc01d4eb0ca565a7"
+revision = "91d38634d1882f0a2151966f8c5c230ce1c0de7b"
 path = "modules/hal/libmetal"
 groups = ["hal"]
 
 [manifest.projects.nix]
-hash = "sha256-EV0+sTcVzGpKGLrS5bjwQ4fZztI8GhH7azScUaUaozA="
+hash = "sha256-xaX5Dp9Vj8ovvHYf6c439WXOflji6J9GtCNGbGeh6Tk="
 
 [[manifest.projects]]
 name = "littlefs"
 url = "https://github.com/zephyrproject-rtos/littlefs"
-revision = "ed0531d59ee37f5fb2762bcf2fc8ba4efaf82656"
+revision = "8f5ca347843363882619d8f96c00d8dbd88a8e79"
 path = "modules/fs/littlefs"
 groups = ["fs"]
 
 [manifest.projects.nix]
-hash = "sha256-oNTrA6tpZRcS6RfP2m2ss4o82nUYcwdbjwLg5JPHYJI="
+hash = "sha256-MuXfpmEE3z0ZOtfjp93aAh/7xZhShmHzwHC5nyN2QQg="
 
 [[manifest.projects]]
 name = "loramac-node"
@@ -395,31 +405,31 @@ hash = "sha256-t6CRkm5TheFvUuc+Qj3JaveWYOaHRH6Pquvlb5YlsOg="
 [[manifest.projects]]
 name = "lvgl"
 url = "https://github.com/zephyrproject-rtos/lvgl"
-revision = "1ed1ddd881c3784049a92bb9fe37c38c6c74d998"
+revision = "b03edc8e6282a963cd312cd0b409eb5ce263ea75"
 path = "modules/lib/gui/lvgl"
 
 [manifest.projects.nix]
-hash = "sha256-StW4k/m6YSPlJDNvf/pZOcbecq5i7Upu3StRJFy6/vo="
+hash = "sha256-akmYjcyRikKxG9W37u+3aal+BbeBltbprmCxkzGAPp4="
 
 [[manifest.projects]]
 name = "mbedtls"
 url = "https://github.com/zephyrproject-rtos/mbedtls"
-revision = "4952e1328529ee549d412b498ea71c54f30aa3b1"
+revision = "5f889934359deccf421554c7045a8381ef75298f"
 path = "modules/crypto/mbedtls"
 groups = ["crypto"]
 
 [manifest.projects.nix]
-hash = "sha256-kiB6ZxMLAEJSxQNRaWj+ggMYmk/QqkHsxCN6YbvPSC8="
+hash = "sha256-RYoQuBokTrN82BJP+yxcwGud+T9WfN1aZURI4pKtzYM="
 
 [[manifest.projects]]
 name = "mcuboot"
 url = "https://github.com/zephyrproject-rtos/mcuboot"
-revision = "346f7374ff4467e40b5594658f8ac67a5e9813c9"
+revision = "990b1fcb367e27056b282f183e819964fdbfe907"
 path = "bootloader/mcuboot"
 groups = ["bootloader"]
 
 [manifest.projects.nix]
-hash = "sha256-6lwcujReqqYwTfCUT6LJ9Q8/tgvg8ghL9KTNj6jgWkk="
+hash = "sha256-F+iMJ42Cbprlw9ZxJNMHOTosWAlXZNpxlrudYp0/zUs="
 
 [[manifest.projects]]
 name = "mipi-sys-t"
@@ -434,21 +444,21 @@ hash = "sha256-rDsj8ZnJIfNaAhrjnx69U0nYVY9T5x5kmMsmFgn3wPA="
 [[manifest.projects]]
 name = "net-tools"
 url = "https://github.com/zephyrproject-rtos/net-tools"
-revision = "93acc8bac4661e74e695eb1aea94c7c5262db2e2"
+revision = "986bfeb040df3d9029366de8aea4ce1f84e93780"
 path = "tools/net-tools"
 groups = ["tools"]
 
 [manifest.projects.nix]
-hash = "sha256-Bst/K21L+NhYzq0icjBdd8Rj4vIOtjJTx7vSvzZlFzk="
+hash = "sha256-XgL/LuMV4OVlSX8afa4K1r4En2vruzkvQXBH5zSH7dc="
 
 [[manifest.projects]]
 name = "open-amp"
 url = "https://github.com/zephyrproject-rtos/open-amp"
-revision = "52bb1783521c62c019451cee9b05b8eda9d7425f"
+revision = "c30a6d8b92fcebdb797fc1a7698e8729e250f637"
 path = "modules/lib/open-amp"
 
 [manifest.projects.nix]
-hash = "sha256-HUI6vKlHgSyg1jAyPz6IrHSPU5sxQkwdElz4yUAXL3I="
+hash = "sha256-WRYNd848wZNb8EfM+XbLb0vqwpK6hncJK7Q29HbU6Co="
 
 [[manifest.projects]]
 name = "openthread"
@@ -462,11 +472,11 @@ hash = "sha256-tmSsRJlMzh/BIdejsgy+EJqAlQxCxsKbm0DLV8tYc3A="
 [[manifest.projects]]
 name = "picolibc"
 url = "https://github.com/zephyrproject-rtos/picolibc"
-revision = "82d62ed1ac55b4e34a12d0390aced2dc9af13fc9"
+revision = "560946f26db075c296beea5b39d99e6de43c9010"
 path = "modules/lib/picolibc"
 
 [manifest.projects.nix]
-hash = "sha256-22TJoxyU/PyyHcLYooOBQtDI0TljkpL8SUQgL3s5R5M="
+hash = "sha256-22aCOAjDfEFtlUX3VCpsa/7VGYjObpYn7EkcyYnj/fg="
 
 [[manifest.projects]]
 name = "segger"
@@ -501,12 +511,12 @@ hash = "sha256-Dx+/fBHS7LabDu8mzfewdLdhoxVl5NO271V2EJZ+Y7g="
 [[manifest.projects]]
 name = "trusted-firmware-m"
 url = "https://github.com/zephyrproject-rtos/trusted-firmware-m"
-revision = "918f32d9fce5e0ee59fc33844b5317b7626ce37a"
+revision = "c150f48855f04d77451a39bfaa80d14eb61d918b"
 path = "modules/tee/tf-m/trusted-firmware-m"
 groups = ["tee"]
 
 [manifest.projects.nix]
-hash = "sha256-eN3bAi6R3kjpwB83LfTl4bg2OK9i5sq4Tm+hH1HEJUI="
+hash = "sha256-76o6C9iSs3BCHlXo9mdZbRY5rIgJHE11uV4bsArY/4g="
 
 [manifest.self]
 path = "bridle"


### PR DESCRIPTION
Updates all flake inputs, including the auxiliary flake providing some required python packages. Since that flake now provides an overlay in addition to individual packages, we can simplify the way the python environment is built.

We also see much fewer invalid version constraints in the relevant `requirements.txt` now, with only two remaining: 
- ruff, where nixpkgs provides v0.11.13 while zephyr insists on v0.11.11 specifically
- sphinx-notfound-page, where nixpkgs provides v1.0.0 while zephyr asks for v1.1.0