### PR TITLE
Fix compile warning in SC18IS604 emulator

### DIFF
--- a/.github/workflows/qa-integration.yml
+++ b/.github/workflows/qa-integration.yml
@@ -263,6 +263,7 @@ jobs:
             --integration --no-detailed-test-id \
             --testsuite-root bridle/tests \
             --testsuite-root zephyr/tests \
+            --tag sc18is604 \
             --tag bridle \
             --tag zephyr
 

--- a/doc/bridle/releases/release-notes-4.2.0.rst
+++ b/doc/bridle/releases/release-notes-4.2.0.rst
@@ -225,6 +225,7 @@ Issue Related Items
 
 These GitHub issues were addressed since project bootstrapping:
 
+* :github:`339` - [BUG] SC18IS604 emulation has compilation warning on zero size VAL
 * :github:`333` - [FER] upgrade to west 1.4.0
 * :github:`325` - [BUG] SPI Loopback test suit files on TiaC Magpie F777NI
 * :github:`320` - [BUG] CMSIS_6 module required by the ARM port for Cortex-M

--- a/drivers/mfd/sc18is604/mfd_sc18is604_emul.c
+++ b/drivers/mfd/sc18is604/mfd_sc18is604_emul.c
@@ -260,6 +260,7 @@ static int mfd_sc18is604_emul_io_spi(const struct emul *target, const struct spi
 		rx_len = tx_len;
 	}
 
+	__ASSERT(rx_len != 0, "SPI IO must always include RX byte(s)");
 	uint8_t rx[rx_len];
 
 	memset(rx, 0, rx_len);


### PR DESCRIPTION
Fix #339 – an array cannot have zero size. Thus a new __ASSERT(rx_len != 0, ...) was add.

ISO 9899:2011 6.7.6.2 (https://www.iso-9899.info/n1570.html#6.7.6):

> **1 Constraints:** If the expression is a constant expression, it shall have a value greater than zero.

> **5 If the size is an expression that is not an integer constant expression:** if it occurs in a declaration at function prototype scope, it is treated as if it were replaced by *; otherwise, each time it is evaluated it shall have a value greater than zero. The size of each instance of a variable length array type does not change during its lifetime.

The above text is true both for a plain array (paragraph 1). For a variable length array (VLA), the behavior is undefined if the expression's value is less than or equal to zero (paragraph 5). This is normative text in the C standard. A compiler is not allowed to implement it differently.
