### PR TITLE
chore: bump devcontainer version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		// Specify version for Zephyr Container
 		// See https://github.com/zephyrproject-rtos/docker-image/releases
 		"args": {
-			"ZEPHYR_TAG": "v0.27.4"
+			"ZEPHYR_TAG": "v0.28.2"
 		}
 	},
 	// Needed for USB devices in container


### PR DESCRIPTION
This will bump the used container tag for the devcontainer to the latest release of the zephyr CI container to have the latest toolchains at hand.