### PR TITLE
chore[devcontainer]: minor fixups for 4.2.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,17 +30,22 @@
 			"settings": {
 				"editor.trimAutoWhitespace": true,
 				"editor.insertFinalNewline": true,
+				"editor.insertSpaces": false,
 				"clangd.arguments": [
 					"--compile-commands-dir=/workspace/build",
 					"--header-insertion=never"
 				],
-				"clangd.path": "clangd-16",
-				"C_Cpp.intelliSenseEngine": "disabled"
+				"clangd.path": "clangd-20",
+				"editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd",
+				"C_Cpp.intelliSenseEngine": "disabled",
+				"python.terminal.activateEnvironment": true,
+				"python.terminal.activateEnvInCurrentTerminal": true
 			},
 			"extensions": [
 				"marus25.cortex-debug",
 				"ms-vscode.cmake-tools",
-				"llvm-vs-code-extensions.vscode-clangd"
+				"llvm-vs-code-extensions.vscode-clangd",
+				"ms-python.python"
 			]
 		}
 	}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -13,12 +13,18 @@ if [ ! -d ".west" ]; then
     west init -l $REPO_NAME
 fi
 
-# Put .clangd file in expected location by clangd
-ln -s $REPO_NAME/.devcontainer/.clangd
-
 # Fetch upstream modules and setup tools
 west update
 west bridle-export
+
+# Put .clang files in expected location by clangd
+ln -s $REPO_NAME/.devcontainer/.clangd
+ln -s zephyr/.clang-format
+
+# Python Setup
+python3 -mvenv .venv
+
+. .venv/bin/activate
 
 pip3 install --upgrade --requirement zephyr/scripts/requirements.txt
 pip3 install --upgrade --requirement $REPO_NAME/scripts/requirements.txt


### PR DESCRIPTION
The clangd path changed due to newer container version. Also the clang-format file from the zephyr project is used for formatting code.

Furthermore python packages are now installed in an virtual env which is automatically activated when a terminal is started.