### PR TITLE
tests: respect board renaming PAN B511 to PAN B611

### DIFF
--- a/tests/quarantine.yaml
+++ b/tests/quarantine.yaml
@@ -52,9 +52,10 @@
     - nrf9280pdk/nrf9280/cpuppr/xip
     - ophelia4ev/nrf54l15/cpuapp
     - ophelia4ev/nrf54l15/cpuflpr
-    - panb511evb/nrf54l15/cpuapp
-    - panb511evb/nrf54l15/cpuflpr
-    - panb511evb/nrf54l15/cpuflpr/xip
+    - panb611evb/nrf54l15/cpuapp
+    - panb611evb/nrf54l15/cpuapp/ns
+    - panb611evb/nrf54l15/cpuflpr
+    - panb611evb/nrf54l15/cpuflpr/xip
     - raytac_an54l15q_db/nrf54l15/cpuapp
     - raytac_an54l15q_db/nrf54l15/cpuflpr
     - raytac_an54l15q_db/nrf54l15/cpuflpr/xip

--- a/zephyr/alt-config/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/zephyr/alt-config/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -21,10 +21,10 @@ tests:
       - mps2/an383
       - mps2/an386
       - mps2/an500
-      - panb511evb/nrf54l15/cpuapp
-      - panb511evb/nrf54l15/cpuapp/ns
-      - panb511evb/nrf54l15/cpuflpr
-      - panb511evb/nrf54l15/cpuflpr/xip
+      - panb611evb/nrf54l15/cpuapp
+      - panb611evb/nrf54l15/cpuapp/ns
+      - panb611evb/nrf54l15/cpuflpr
+      - panb611evb/nrf54l15/cpuflpr/xip
       - mimxrt700_evk/mimxrt798s/cm33_cpu1
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54l15dk/nrf54l10/cpuapp/ns


### PR DESCRIPTION
Due to marketing reasons the naming was adjusted from panb511 to panb611.