### PR TITLE
More documentation about Binary Blobs and evaluate Wi-Fi Network with RPi Pico W

### DIFF
--- a/.github/workflows/qa-integration.yml
+++ b/.github/workflows/qa-integration.yml
@@ -128,6 +128,11 @@ jobs:
           uv pip install --upgrade --requirement zephyr/scripts/requirements-compliance.txt
           uv pip install --upgrade --requirement bridle/scripts/requirements-build.txt
 
+      - name: Fetch binary blobs
+        working-directory: workspace
+        run: |
+          west blobs --auto-accept fetch
+
       - name: Build samples
         working-directory: workspace
         run: |

--- a/doc/bridle/dm_adding_code.rst
+++ b/doc/bridle/dm_adding_code.rst
@@ -177,7 +177,7 @@ For example:
          remote: tiacsys
          revision: v0.1.5
          import: true
-       # Example for how to override a repository in the BRIDLE with your own:
+       # Example for how to override a repository in BRIDLE with your own:
        - name: mcuboot
          remote: your-remote
          revision: your-mcuboot-fork-SHA-or-branch
@@ -207,6 +207,7 @@ and *your-ncs-fork*, respectively), as shown in the following code:
    west init -m https:\ //github.com/*your-name/your-application* *your-tiacsys-fork*
    cd *your-tiacsys-fork*
    west update
+   west blobs --auto-accept fetch
 
 After that, to modify the |BRIDLE| version associated with your app,
 change the ``revision`` value in the manifest file to the `tiac-bridle`_

--- a/doc/bridle/dm_code_base.rst
+++ b/doc/bridle/dm_code_base.rst
@@ -134,6 +134,28 @@ information about manifests can be found in the
 :external+zephyr:ref:`west manifest section <west-manifests>`
 of the |ZEPHYR| documentation.
 
+Binary Blobs
+============
+
+.. tsn-include:: contribute/bin_blobs.rst
+   :docset: zephyr
+   :start-at: In the context of an operating system
+   :end-before: Software license
+
+.. tsn-include:: contribute/bin_blobs.rst
+   :docset: zephyr
+   :start-at: Most binary blobs are distributed under proprietary licenses
+   :end-before: Hosting
+
+.. tsn-include:: contribute/bin_blobs.rst
+   :docset: zephyr
+   :start-at: The blobs themselves must be specified in
+   :end-before: Each blob which may be fetched must be individually identified
+
+Blobs are fetched from official third-party sources by the ``west blobs``
+:external+zephyr:ref:`command <west-blobs>`. For details read the related
+Zephyr upstream documentation :external+zephyr:ref:`bin-blobs`.
+
 Revisions
 *********
 

--- a/doc/bridle/dm_managing_code.rst
+++ b/doc/bridle/dm_managing_code.rst
@@ -25,6 +25,17 @@ repositories:
   file. They are entirely managed by west, which will clone them or check
   out a specific revision of them every time you run ``west update``.
 
+* The west :external+zephyr:ref:`binary blobs <bin-blobs>`.
+  Those are defined in some (not all) west projct entries in their Zephyr
+  module file. They are entirely managed by west, which will download,
+  clone or check out a specific revision of them every time you run
+  ``west blobs fetch``.
+
+  .. tsn-include:: contribute/bin_blobs.rst
+     :docset: zephyr
+     :start-at: Most binary blobs are distributed under proprietary licenses
+     :end-before: Hosting
+
 .. _dm-wf-get-bridle:
 
 Obtaining a copy of |BRIDLE|
@@ -38,6 +49,7 @@ in a folder named :file:`tiacsys`, use the following commands:
    west init -m https://github.com/tiacsys/bridle.git --mr {revision} tiacsys
    cd tiacsys
    west update
+   west blobs --auto-accept fetch
 
 Replace ``{revision}`` with any revision you wish to obtain. This can be
 ``main`` if you want the latest state, or any released version (e.g.
@@ -60,6 +72,7 @@ switch to a new revision, then you only need to do the following:
    # or check out a release
    git checkout {revision}
    west update
+   west blobs --auto-accept fetch
 
 Where ``{remote}`` is the Git remote that points to the official |TIAC|
 repository. This is called ``origin`` by default for the `tiac-bridle`_

--- a/doc/bridle/gs_installing.rst
+++ b/doc/bridle/gs_installing.rst
@@ -841,6 +841,17 @@ To clone the repositories, complete the following steps:
 
          west update
 
+#. Enter the following command to fetch all known binary blobs:
+
+   .. container:: highlight highlight-console notranslate
+
+      .. parsed-literal::
+
+         west blobs --auto-accept fetch
+
+   To remove outdated artifacts from the build system, you can also precede
+   it with :command:`west blobs clean`.
+
 #. Export the :external+zephyr:ref:`Zephyr CMake package <cmake_pkg>` and
    also for |BRIDLE|. This allows CMake to automatically load the boilerplate
    code required for building |BRIDLE| applications:

--- a/doc/bridle/introduction.rst
+++ b/doc/bridle/introduction.rst
@@ -182,7 +182,10 @@ makes sure your workspace contains Git repositories matching the projects
 defined in the manifest file. Whenever you check out a different revision
 in your manifest repository, you should run :command:`west update` to make
 sure your workspace contains the project repositories the new revision expects
-(according to the manifest file).
+(according to the manifest file). For some target systems, it is necessary to
+also install the associated :external+zephyr:ref:`bin-blobs` in the west
+workspace. The second important west command, :command:`west blobs`, is
+responsible for this.
 
 For more information about :command:`west init`, :command:`west update`, and
 other built-in commands, see :external+zephyr:ref:`west-built-in-cmds`. For more

--- a/doc/bridle/releases/release-notes-4.3.0.rst
+++ b/doc/bridle/releases/release-notes-4.3.0.rst
@@ -194,7 +194,7 @@ Build Infrastructure
 * tbd.
 * tbd.
 * tbd.
-
+* Bridle now requires binary blobs that have to fetch with :command:`west blobs`.
 
 Documentation
 =============
@@ -206,7 +206,6 @@ Documentation
 3. tbd.
 4. Update all output messages in documentation to be in sync with the upcoming
    Bridle version v4.3.0, based on Zephyr v4.3 (samples and tests).
-
 
 Issue Related Items
 *******************

--- a/samples/helloshell/README.rst
+++ b/samples/helloshell/README.rst
@@ -298,3 +298,295 @@ Sample Output
       0x200105e8 logging                          (real size  768):   unused  584     usage  184 /  768 (23 %)
       0x200114f0 idle                             (real size  320):   unused  256     usage   64 /  320 (20 %)
       0x20015e80 IRQ 00                           (real size 2048):   unused 1816     usage  232 / 2048 (11 %)
+
+TCP/IP Network over Wi-Fi on the RPi Pico W
+===========================================
+
+This project provides an extended board-specific configuration for the
+|RPi Pico W| with a pre-activated :external+zephyr:ref:`TCP/IP network stack
+<network_stack_architecture>` via the Wi-Fi chip made by Infineon. It have to
+build at least with the Zephyr upstream :external+zephyr:ref:`snippet-wifi-ip`
+and optional with the Bridle :ref:`snippet-usb-console`:
+
+   .. zephyr-app-commands::
+      :app: bridle/samples/helloshell
+      :build-dir: helloshell-rpi_pico_w
+      :board: rpi_pico/rp2040/w
+      :snippets: "usb-console wifi-ip"
+      :west-args: -p
+      :flash-args: -r uf2
+      :goals: flash
+      :host-os: unix
+      :compact:
+
+You should see the following message on the console:
+
+   .. container:: highlight highlight-console notranslate
+
+      .. parsed-literal::
+
+         WLAN MAC Address : 29:F7:28:FC:67:1C
+         WLAN Firmware    : wl0: Jun  5 2024 06:33:59 version 7.95.88 (cf1d613 CY) FWID 01-7b7cf51a
+         WLAN CLM         : API: 12.2 Data: 9.10.39 Compiler: 1.29.4 ClmImport: 1.36.3 Creation: 2024-04-16 21:20:55
+         WHD VERSION      : 3.3.2.25168 : v3.3.2 : GCC 12.2 : 2024-12-06 06:53:17 +0000
+
+         \*\*\*\*\* delaying boot 4000ms (per build configuration) \*\*\*\*\*
+         [00:00:04.113,000] :byl:`<wrn> udc_rpi: BUS RESET`
+         [00:00:04.192,000] :byl:`<wrn> udc_rpi: BUS RESET`
+         \*\*\* Booting Zephyr OS build v\ |zephyr_version_number_em| \*\*\*
+         Hello World! I'm THE SHELL from rpi_pico
+         [00:00:07.834,000] <inf> net_config: Initializing network
+         [00:00:07.834,000] <inf> net_config: Waiting interface 1 (0x20001940) to be up...
+         [00:00:07.834,000] <inf> net_config: Running dhcpv4 client...
+         [00:00:07.834,000] <inf> net_config: Running dhcpv6 client...
+
+Simple test execution on target
+-------------------------------
+
+(text in bold is a command input)
+
+   .. admonition:: Network connect over Wi-Fi chip with system date before and after
+      :class: note dropdown toggle-shown
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **date get**
+            1970-01-01 00:00:29 UTC
+
+      :brd:`Replace` the values :command:`<key_management>`, :command:`<SSID>`
+      and :command:`<passphrase>` with your own, e.g. :command:`-k 1` for
+      :emphasis:`WPA2-PSK`! Use the command :command:`wifi connect` without
+      parameters to see online help with more details.
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **wifi connect -s <SSID> -k <key_management> -p <passphrase>**
+            Connected
+            Connection requested
+            [00:04:57.840,000] <inf> net_dhcpv4: Received: 192.168.10.197
+            [00:04:57.841,000] <inf> net_config: IPv4 address: 192.168.10.197
+            [00:04:57.841,000] <inf> net_config: Lease time: 28800 seconds
+            [00:04:57.841,000] <inf> net_config: Subnet: 255.255.255.0
+            [00:04:57.842,000] <inf> net_config: Router: 192.168.10.1
+            [00:04:59.480,000] :brd:`<err> net_dhcpv6: Failed to configure DHCPv6 address`
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **date get**
+            2025-08-31 18:28:26 UTC
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net iface**
+            Default interface: 1
+
+
+            Interface wlan0 (0x20001940) (WiFi) [1]
+            ===============================
+            Link addr : 29:F7:28:FC:67:1C
+            MTU       : 1500
+            Flags     : AUTO_START,IPv4,IPv6
+            Device    : airoc-wifi\ @\ 0 (0x1004d1f0)
+            Status    : oper=UP, admin=UP, carrier=ON
+            Ethernet capabilities supported:
+                    MAC address filtering
+            Ethernet PHY device: <none> (0)
+            IPv6 unicast addresses (max 2):
+                    fe80::2acd:c1ff:fe02:74f4 autoconf preferred infinite
+                    fd9c:33d7:ba99:0:2acd:c1ff:fe02:74f4 autoconf preferred infinite
+            IPv6 multicast addresses (max 3):
+                    ff02::1
+                    ff02::1:ff02:74f4
+            IPv6 prefixes (max 2):
+                    fd9c:33d7:ba99::/64 infinite
+            IPv6 hop limit           : 64
+            IPv6 base reachable time : 30000
+            IPv6 reachable time      : 20783
+            IPv6 retransmit timer    : 0
+            DHCPv6 state             : disabled
+            IPv4 unicast addresses (max 1):
+                    192.168.10.197/255.255.255.0 DHCP preferred
+            IPv4 multicast addresses (max 2):
+                    224.0.0.1
+            IPv4 gateway : 192.168.10.1
+            DHCPv4 lease time : 28800
+            DHCPv4 renew time : 14400
+            DHCPv4 server     : 192.168.10.10
+            DHCPv4 requested  : 192.168.10.197
+            DHCPv4 state      : bound
+            DHCPv4 attempts   : 2
+            DHCPv4 state      : bound
+
+   .. admonition:: DNS server list and name lookup query
+      :class: note dropdown
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net dns**
+            DNS servers:
+                    192.168.10.10:53 via wlan0 (DHCP)
+                    192.168.10.20:53 via wlan0 (DHCP)
+                    [fd9c:33d7:ba99::1]:53 via wlan0 (IPv6 RA)
+            Pending queries:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net dns query google.com**
+            Query for 'google.com' sent.
+            dns: 142.250.185.142
+            dns: All results received
+
+   .. admonition:: ICMP/Ping check in WAN and LAN
+      :class: note dropdown
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net ping 142.250.185.142**
+            PING 142.250.185.142
+            28 bytes from 142.250.185.142 to 192.168.10.197: icmp_seq=1 ttl=118 time=28 ms
+            28 bytes from 142.250.185.142 to 192.168.10.197: icmp_seq=2 ttl=118 time=27 ms
+            28 bytes from 142.250.185.142 to 192.168.10.197: icmp_seq=3 ttl=118 time=28 ms
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net ping 192.168.10.1**
+            PING 192.168.10.1
+            28 bytes from 192.168.10.1 to 192.168.10.197: icmp_seq=1 ttl=64 time=15 ms
+            28 bytes from 192.168.10.1 to 192.168.10.197: icmp_seq=2 ttl=64 time=8 ms
+            28 bytes from 192.168.10.1 to 192.168.10.197: icmp_seq=3 ttl=64 time=9 ms
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net ping fd9c:33d7:ba99::1**
+            PING fd9c:33d7:ba99::1
+            8 bytes from fd9c:33d7:ba99::1 to fd9c:33d7:ba99:0:2acd:c1ff:fe02:74f4: icmp_seq=1 ttl=64 time=10 ms
+            8 bytes from fd9c:33d7:ba99::1 to fd9c:33d7:ba99:0:2acd:c1ff:fe02:74f4: icmp_seq=2 ttl=64 time=9 ms
+            8 bytes from fd9c:33d7:ba99::1 to fd9c:33d7:ba99:0:2acd:c1ff:fe02:74f4: icmp_seq=3 ttl=64 time=9 ms
+
+   .. admonition:: ARP list, list of connections, and interface statistics
+      :class: note dropdown
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net arp**
+                 Interface  Link              Address
+            [ 0] 1          BC:EE:7B:32:E5:D0 192.168.10.1
+            [ 1] 1          00:80:77:84:BF:81 192.168.10.10
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net conn**
+                 Context    Iface  Flags            Local             Remote
+            [ 1] 0x20005c8c 1      4DU      0.0.0.0:42759          0.0.0.0:0
+            [ 2] 0x20005d3c 1      4DU      0.0.0.0:38313          0.0.0.0:0
+            [ 3] 0x20005dec 1      6DU         [::]:38774             [::]:0
+
+                 Handler    Callback  Proto            Local                  Remote
+            [ 1] 0x20006510 0x10024b79  UDP       [::]:38774                  [::]:0
+            [ 2] 0x200065a0 0x10024b79  UDP    0.0.0.0:38313               0.0.0.0:0
+            [ 3] 0x20006558 0x10024b79  UDP    0.0.0.0:42759               0.0.0.0:0
+            [ 4] 0x200065e8 0x10030165  UDP         [::]:546                  [::]:0
+            [ 5] 0x20006630 0x100310d9  UDP       0.0.0.0:68               0.0.0.0:0
+
+            TCP        Context   Src port Dst port   Send-Seq   Send-Ack  MSS    State
+            No TCP connections
+            :bgn:`Set CONFIG_NET_TCP_LOG_LEVEL_DBG to enable TCP debugging support.`
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **net stats**
+
+            Interface 0x20001940 (WiFi) [1]
+            ===============================
+            IPv6 recv      34       sent    38      drop    3       forwarded       0
+            IPv6 ND recv   21       sent    22      drop    1
+            IPv6 MLD recv  0        sent    2       drop    0
+            IPv4 recv      40       sent    39      drop    2       forwarded       0
+            IP vhlerr      49       hblener 0       lblener 0
+            IP fragerr     0        chkerr  0       protoer 49
+            ICMP recv      61       sent    64      drop    0
+            ICMP typeer    0        chkerr  0
+            IGMP recv      0        sent    0       drop    0
+            UDP recv       8        sent    8       drop    5
+            UDP chkerr     0
+            TCP bytes recv 0        sent    0       resent  0
+            TCP seg recv   0        sent    0       drop    0
+            TCP seg resent 0        chkerr  0       ackerr  0
+            TCP seg rsterr 0        rst     0
+            TCP conn drop  0        connrst 0
+            TCP pkt drop   0
+            DNS recv       3        sent    4       drop    1
+            Bytes received 42752
+            Bytes sent     6278
+            Processing err 11
+
+   .. admonition:: Wi-Fi interface statistics and SSID scan
+      :class: note dropdown
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **wifi statistics**
+            Statistics for Wi-Fi interface 0x20001940 [1]
+            Bytes received   : 45148
+            Bytes sent       : 6622
+            Packets received : 163
+            Packets sent     : 96
+            Receive errors   : 0
+            Send errors      : 0
+            Bcast received   : 0
+            Bcast sent       : 0
+            Mcast received   : 0
+            Mcast sent       : 0
+            Beacons received : 0
+            Beacons missed   : 0
+            Unicast received : 0
+            Unicast sent     : 0
+            Overrun count    : 0
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **wifi scan**
+            Scan requested
+
+            Num | SSID               (len) | Chan (Band)   | RSSI | Security         | BSSID             | MFP
+            1   | PYUR Community     14    | 1    (2.4GHz) | -77  | WPA2 Enterprise  | B5:7F:4F:4E:05:AC | Disable
+            2   | PYUR B6672         10    | 1    (2.4GHz) | -75  | WPA2-PSK         | 0B:A2:AB:0C:C6:A1 | Disable
+            3   | FRITZ!Box 7430 XR  17    | 1    (2.4GHz) | -82  | WPA2-PSK         | A8:34:B0:1E:D9:79 | Disable
+            4   | o2-WLAN65          9     | 2    (2.4GHz) | -82  | WPA2-PSK         | 5A:8B:47:4C:80:9C | Disable
+            5   | Fluchtweg          9     | 6    (2.4GHz) | -50  | WPA2-PSK         | 44:12:1A:18:24:C5 | Disable
+            6   | Hekatoncheiren     14    | 6    (2.4GHz) | -50  | WPA2-PSK         | B2:05:A9:B0:DB:9A | Disable
+            7   | FRITZ!Box 7430 SH  17    | 11   (2.4GHz) | -77  | WPA2-PSK         | 34:3B:8A:C0:B3:37 | Disable
+            8   | Fallschirm         10    | 11   (2.4GHz) | -70  | WPA2-PSK         | F9:15:89:6C:7D:59 | Disable
+            9   | Fallschirm Gast    15    | 11   (2.4GHz) | -71  | WPA2-PSK         | 14:AD:F1:A0:07:F1 | Disable
+            Scan request done
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **wifi status**
+            :byl:`Status request failed`

--- a/samples/helloshell/boards/rpi_pico_rp2040_w.conf
+++ b/samples/helloshell/boards/rpi_pico_rp2040_w.conf
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+##############################################################################
+########                                                              ########
+########   U S E   I T   W I T H   T H E   wifi-ip   S N I P P E T    ########
+########                                                              ########
+##############################################################################
+
+CONFIG_TEST_RANDOM_GENERATOR=y
+
+# enable Infineon AIROC SoC Wi-Fi and related shell commands
+CONFIG_WIFI=y
+CONFIG_WIFI_LOG_LEVEL_ERR=y
+
+# enable network stack with TCP/IP and related shell commands
+CONFIG_NETWORKING=y
+CONFIG_NET_SHELL=y
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_NET_LOG=y
+CONFIG_NET_DHCPV4_LOG_LEVEL_INF=y
+CONFIG_NET_DHCPV6_LOG_LEVEL_INF=y
+CONFIG_NET_MAX_CONTEXTS=10
+CONFIG_NET_TX_STACK_SIZE=2048
+CONFIG_NET_RX_STACK_SIZE=2048
+CONFIG_NET_ARP=y
+CONFIG_NET_TCP=y
+CONFIG_NET_UDP=y
+CONFIG_NET_STATISTICS=y
+CONFIG_NET_STATISTICS_USER_API=y
+CONFIG_NET_STATISTICS_PERIODIC_OUTPUT=n
+
+# enable network settings for applications
+CONFIG_NET_CONFIG_SETTINGS=y
+CONFIG_NET_CONFIG_AUTO_INIT=y
+CONFIG_NET_CONFIG_NEED_IPV4=y
+CONFIG_NET_CONFIG_NEED_IPV6=n
+CONFIG_NET_CONFIG_CLOCK_SNTP_INIT=y
+CONFIG_NET_CONFIG_SNTP_INIT_RESYNC=y
+CONFIG_NET_CONFIG_SNTP_INIT_SERVER="0.pool.ntp.org"
+
+# enable basic network services
+CONFIG_DNS_RESOLVER=y
+CONFIG_DNS_RESOLVER_MAX_SERVERS=4
+CONFIG_SNTP=y

--- a/samples/helloshell/sample.yaml
+++ b/samples/helloshell/sample.yaml
@@ -120,6 +120,7 @@ tests:
     min_flash: 128
     extra_args:
       - CMAKE_BUILD_TYPE=ZDebug
+      - platform:rpi_pico/rp2040/w:"SNIPPET=wifi-ip"
     integration_platforms:
       - qemu_x86
       - qemu_x86/atom/nokpti
@@ -210,6 +211,7 @@ tests:
     extra_args:
       - CMAKE_BUILD_TYPE=ZDebug
       - EXTRA_CONF_FILE="prj-hwstartup.conf"
+      - platform:rpi_pico/rp2040/w:"SNIPPET=wifi-ip"
       - platform:vccgnd_bluepill_stm32f103cb/stm32f103xb:"CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y"
       - platform:vccgnd_bluepill_stm32f103c8/stm32f103xb:"CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y"
       - platform:weact_bluepillplus_ch32v203c8/ch32v203:"CONFIG_FLASH=n"
@@ -230,6 +232,7 @@ tests:
     extra_args:
       - CMAKE_BUILD_TYPE=ZDebug
       - EXTRA_CONF_FILE="prj-minimal.conf"
+      - platform:rpi_pico/rp2040/w:"SNIPPET=wifi-ip"
       - platform:vccgnd_bluepill_stm32f072cb/stm32f072xb:"CONFIG_ADC=y"
       - platform:vccgnd_bluepill_stm32f072cb/stm32f072xb:"CONFIG_ADC_SHELL=y"
       - platform:vccgnd_bluepill_stm32f072cb/stm32f072xb:"CONFIG_I2C=y"
@@ -252,6 +255,7 @@ tests:
     extra_args:
       - CMAKE_BUILD_TYPE=ZDebug
       - EXTRA_CONF_FILE="prj-tiny.conf"
+      - platform:rpi_pico/rp2040/w:"SNIPPET=wifi-ip"
       - platform:vccgnd_bluepill_stm32f051c8/stm32f051x8:"CONFIG_ADC=y"
       - platform:vccgnd_bluepill_stm32f051c8/stm32f051x8:"CONFIG_ADC_SHELL=y"
       - platform:vccgnd_bluepill_stm32f051c8/stm32f051x8:"CONFIG_I2C=y"


### PR DESCRIPTION
Since Bridle also supports targets with radio modules a few specific builds may be depend on external proprietary (EULA protected) binary artefacts. West always know about this and should be used to download, clone or checkout the correct releases. Even this workflow, the how to and references to yet more upstream documentation, is now part of the Bridle documentation.

Further, for the Raspberry Pi Pico W (contains an Infineon [CYW43439](https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/wi-fi-4-802.11n/cyw43439/) 2.4 GHz Wi-Fi/Bluetooth module that requires a binary blob) Bridle now provides a full pre-configuration and ready to use TCP/IP Network within Bridle's _"Hello SHELL"_ sample.