### PR TITLE
ci: github: doc: free disk space on start

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -60,6 +60,17 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Install packages
         run: |
           sudo add-apt-repository -y -u ppa:tiac-systems/doxygen


### PR DESCRIPTION
For a few days now, building the documentation has been reaching the natural limits of the disk size provided by GitHub for this workflow. However, since the build depends exclusively on Ubuntu system packages and the Zephyr SDK stored in the cache, it is possible to completely delete the tools provided by GitHub for various scripting languages, .Net, or Android, thereby significantly increasing disk capacity.