### PR TITLE
loopback_test: tiac_magpie: remove SPI_STM32_USE_HW_SS flag

### DIFF
--- a/boards/shields/loopback_test/boards/magpie_f777ni.conf
+++ b/boards/shields/loopback_test/boards/magpie_f777ni.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 TiaC Systems
+# Copyright (c) 2021-2026 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,7 +6,6 @@
 # TiaC Magpie F777NI board
 
 CONFIG_SPI_LOOPBACK_MODE_LOOP=n
-CONFIG_SPI_STM32_USE_HW_SS=y
 CONFIG_SPI_STM32_DMA=n
 CONFIG_SPI_STM32_INTERRUPT=y
 

--- a/boards/shields/loopback_test/boards/magpie_f777ni.overlay
+++ b/boards/shields/loopback_test/boards/magpie_f777ni.overlay
@@ -1,18 +1,23 @@
 /*
- * Copyright (c) 2021-2025 TiaC Systems
+ * Copyright (c) 2021-2026 TiaC Systems
  * Copyright (c) 2021 Li-Pro.Net
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <freq.h>
 
+&tmph_spi1 {
+	/* Force operation in "Soft NSS" mode without CS/NSS pin. */
+	st,soft-nss;
+}; // tmph_spi1
+
 &tmph_spi1_fast {
 	/*
-	 * Reduce fast transfer clock to max. 15 MHz,
+	 * Reduce fast transfer clock to max. 12 MHz,
 	 * because of missing DMA setup.
 	 */
-	spi-max-frequency = <DT_FREQ_M(15)>;
-}; // tmph_spi1
+	spi-max-frequency = <DT_FREQ_M(12)>;
+}; // tmph_spi1_fast
 
 &tmph_spi2 {
 	status = "disabled";	/* conflicts with tmph_i2c2 */


### PR DESCRIPTION
Related to Zephyr upstream commit 0d28bc1fb269.

The Kconfig option `CONFIG_SPI_STM32_USE_HW_SS` has been removed. SPI operation mode is now selected automatically based on DTS configuration: instances with either of the `cs-gpios` or new `st,soft-nss` property operate in **_"Soft NSS"_ mode**, while all other instances operate in **_"Hard NSS"_ mode**.

The `loopback_test` shield for the `magpie_f777ni` now respect this.