### PR TITLE
requirements: fix Sphinx package version

### DIFF
--- a/zephyr/requirements-doc.txt
+++ b/zephyr/requirements-doc.txt
@@ -15,6 +15,6 @@ sphinx-tsn-theme~=2024.11
 sphinxcontrib-mscgen~=0.6
 sphinxcontrib-programoutput~=0.18
 sphinxcontrib-svg2pdfconverter~=1.3
-sphinx~=8.2,<8.3
+sphinx~=8.1,<8.3
 sphobjinv~=2.3
 # zephyr-keep-sorted-stop


### PR DESCRIPTION
Return to version 8.1, as Sphinx v8.2 and above requires Python v3.11, but Bridle will continue to support Ubuntu 22.04 LTS with its Python v3.10.