### PR TITLE
Fix on CI and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		// Specify version for Zephyr Container
 		// See https://github.com/zephyrproject-rtos/docker-image/releases
 		"args": {
-			"ZEPHYR_TAG": "v0.28.2"
+			"ZEPHYR_TAG": "v0.29.1"
 		}
 	},
 	// Needed for USB devices in container

--- a/doc/bridle/releases/release-notes-4.4.0.rst
+++ b/doc/bridle/releases/release-notes-4.4.0.rst
@@ -116,6 +116,7 @@ For more details, see: :ref:`repos_and_revs`.
        .. zephyr-keep-sorted-start re(^\s+\| \*+\w)
 
        | **crypto** : *mbedtls*
+       | **crypto** : *tf-psa-crypto*
        | **crypto** : *tinycrypt*
 
        .. zephyr-keep-sorted-stop
@@ -298,6 +299,9 @@ Build Infrastructure
 * On display level, for the ST7789V and ILI9xxx driver, the current
   ``BGR_565`` format string was renamed to the now valid value ``RGB_565X``.
 * Switching to Zephyr SDK v1 (1.0.1), which is now mandatory.
+* Enable support for the TF-PSA-Crypto repository as Zephyr module in the
+  West manifest. The PSA Cryptography API is required by some boards with
+  WiFi and TLS support, e.g. Raspberry Pi Pico W/2W.
 
 
 Documentation

--- a/doc/bridle/releases/release-notes-4.4.0.rst
+++ b/doc/bridle/releases/release-notes-4.4.0.rst
@@ -321,6 +321,8 @@ Issue Related Items
 
 These GitHub issues were addressed since project bootstrapping:
 
+* :github:`427` - [BUG] Fix CMake Error in QA Acceptance Sample Tests
+* :github:`426` - [FCR] Bump devcontainer also to CI Docker Image v0.29.1
 * :github:`424` - [FCR] Upgrade to Zephyr SDK 1.0.1 and CI container 0.29.1
 * :github:`407` - [HW] Cytron MOTION 2350 Pro
 * :github:`394` - [HW] Raspberry Pi Pico 2/2W

--- a/submanifests/zephyr.yml
+++ b/submanifests/zephyr.yml
@@ -103,6 +103,7 @@ manifest:
           - psa-arch-tests
           - segger
           - tf-m-tests
+          - tf-psa-crypto
           - tinycrypt
           - trusted-firmware-a
           - trusted-firmware-m


### PR DESCRIPTION
fixes #427 and #426

- fix QA Acceptance Sample Tests on CI
- bump devcontainer also to CI Docker Image v0.29.1