### PR TITLE
Freeze to Zephyr's v4.4.0 release

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -81,7 +81,7 @@ jobs:
       # are run in reverse order (and you do not want to cleanup before the
       # caching is saved).
       - name: Clean working directory
-        uses: tiacsys/clean-after-action@v3
+        uses: tiacsys/clean-after-action@v4
         #
         # Could also be implemented with the new pre- and post-job hook scripts:
         #
@@ -107,7 +107,7 @@ jobs:
           sudo apt-get install -y doxygen mscgen graphviz lcov
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           working-directory: workspace
           enable-cache: true

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 TiaC Systems
+# Copyright (c) 2021-2026 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/qa-acceptance.yml
+++ b/.github/workflows/qa-acceptance.yml
@@ -88,7 +88,7 @@ jobs:
       # are run in reverse order (and you do not want to cleanup before the
       # caching is saved).
       - name: Clean working directory
-        uses: tiacsys/clean-after-action@v3
+        uses: tiacsys/clean-after-action@v4
         #
         # Could also be implemented with the new pre- and post-job hook scripts:
         #
@@ -108,7 +108,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           working-directory: workspace
           enable-cache: true

--- a/.github/workflows/qa-compliance.yml
+++ b/.github/workflows/qa-compliance.yml
@@ -95,7 +95,7 @@ jobs:
           git log --pretty=oneline --decorate --max-count=10
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           working-directory: workspace
           enable-cache: true

--- a/.github/workflows/qa-integration-apps.yml
+++ b/.github/workflows/qa-integration-apps.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   qa-cannectivity-integration:
-    name: Run integration tests for samples
+    name: Run integration tests for cannectivity
     if: ${{ github.repository_owner == 'tiacsys' }}
     runs-on: [self-hosted, ci-32g-x8, linux, x64, container, for-zephyr-qa]
     container:
@@ -50,7 +50,7 @@ jobs:
       # are run in reverse order (and you do not want to cleanup before the
       # caching is saved).
       - name: Clean working directory
-        uses: tiacsys/clean-after-action@v3
+        uses: tiacsys/clean-after-action@v4
         #
         # Could also be implemented with the new pre- and post-job hook scripts:
         #
@@ -70,7 +70,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           working-directory: workspace
           enable-cache: true

--- a/.github/workflows/qa-integration-hil.yml
+++ b/.github/workflows/qa-integration-hil.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   qa-tiac_magpie-integration:
-    name: Run integration tests on targets
+    name: Run integration tests on TiaC Magpie
     if: ${{ github.repository_owner == 'tiacsys' }}
     runs-on: [self-hosted, linux, gnuarmemb, zephyr-sdk, tiac_magpie]
     defaults:
@@ -37,7 +37,7 @@ jobs:
       # are run in reverse order (and you do not want to cleanup before the
       # caching is saved).
       - name: Clean working directory
-        uses: tiacsys/clean-after-action@v3
+        uses: tiacsys/clean-after-action@v4
         #
         # Could also be implemented with the new pre- and post-job hook scripts:
         #
@@ -57,7 +57,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           working-directory: workspace
           enable-cache: true

--- a/.github/workflows/qa-integration.yml
+++ b/.github/workflows/qa-integration.yml
@@ -50,7 +50,7 @@ jobs:
       # are run in reverse order (and you do not want to cleanup before the
       # caching is saved).
       - name: Clean working directory
-        uses: tiacsys/clean-after-action@v3
+        uses: tiacsys/clean-after-action@v4
         #
         # Could also be implemented with the new pre- and post-job hook scripts:
         #
@@ -70,7 +70,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           working-directory: workspace
           enable-cache: true
@@ -191,7 +191,7 @@ jobs:
       # are run in reverse order (and you do not want to cleanup before the
       # caching is saved).
       - name: Clean working directory
-        uses: tiacsys/clean-after-action@v3
+        uses: tiacsys/clean-after-action@v4
         #
         # Could also be implemented with the new pre- and post-job hook scripts:
         #
@@ -211,7 +211,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           working-directory: workspace
           enable-cache: true

--- a/doc/_extensions/bridle/table_from_rows.py
+++ b/doc/_extensions/bridle/table_from_rows.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 TiaC Systems
 # Copyright (c) 2020 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -9,7 +10,6 @@ from pathlib import Path
 import yaml
 from docutils import io, statemachine
 from docutils.parsers.rst import directives
-from docutils.utils.error_reporting import ErrorString
 from sphinx.util.docutils import SphinxDirective
 
 __version__ = '0.0.2'
@@ -96,7 +96,7 @@ class TableFromRows(SphinxDirective):
             include_file = io.FileInput(source_path=source_path)
         except OSError as error:
             raise self.severe(
-                f'Problems with "{self.name}" directive path:\n{ErrorString(error)}.'
+                f'Problems with "{self.name}" directive path:\n{io.error_string(error)}.'
             ) from error
         lines = include_file.readlines()
         header_lines = self._load_section(lines, header_section)

--- a/doc/_extensions/tsn_include/tsn_include.py
+++ b/doc/_extensions/tsn_include/tsn_include.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 TiaC Systems
+# Copyright (c) 2021-2026 TiaC Systems
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -13,7 +13,6 @@ import os.path
 
 from docutils import io, statemachine
 from docutils.parsers.rst import directives
-from docutils.utils.error_reporting import ErrorString, SafeString
 from sphinx.util.docutils import SphinxDirective
 
 
@@ -75,12 +74,12 @@ class TsnInclude(SphinxDirective):
         except UnicodeEncodeError:
             raise self.severe(
                 f'Problems with "{self.name}" directive path:\n'
-                f'Cannot encode input file path "{SafeString(path)}" '
+                f'Cannot encode input file path "{str(path)}" '
                 '(wrong locale?).'
             ) from None
         except OSError as error:
             raise self.severe(
-                f'Problems with "{self.name}" directive path:\n{ErrorString(error)}.'
+                f'Problems with "{self.name}" directive path:\n{io.error_string(error)}.'
             ) from error
 
         # Get to-be-included content
@@ -94,7 +93,7 @@ class TsnInclude(SphinxDirective):
                 rawtext = include_file.read()
         except UnicodeError as error:
             raise self.severe(
-                f'Problem with "{self.name}" directive:\n{ErrorString(error)}'
+                f'Problem with "{self.name}" directive:\n{io.error_string(error)}'
             ) from error
         # start-at/start-after and end-at/end-before: no restrictions on
         # newlines in match-text, and no restrictions on matching inside

--- a/doc/bridle/links.txt
+++ b/doc/bridle/links.txt
@@ -1,5 +1,7 @@
 .. ### Links to Zephyr
 
+.. |Zephyr RTOS Project| replace:: :strong:`Zephyr RTOS Project`
+.. _`Zephyr RTOS Project`: https://zephyrproject.org/
 .. |Zephyr Project| replace:: :strong:`Zephyr Project`
 .. _`Zephyr Project`: https://zephyrproject.org/
 .. _`Zephyr Project documentation`: http://docs.zephyrproject.org/
@@ -408,7 +410,11 @@
 
 .. _`Sphinx Documentation`: https://www.sphinx-doc.org/en/master/contents.html
 .. _`Sphinx HTML theming`: https://www.sphinx-doc.org/en/master/usage/theming.html
+.. _`Sphinx theme`: https://www.sphinx-doc.org/en/master/usage/theming.html
 .. _`reStructuredText Primer`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _`reStructuredText (RST)`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _`reStructuredText`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _`RST`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _`Li-Pro.Net Sphinx Primer`: https://lpn-doc-sphinx-primer.readthedocs.io/en/latest/
 
 .. _`sitemaps.org`: https://sitemaps.org/protocol.html

--- a/doc/bridle/versions.txt.in
+++ b/doc/bridle/versions.txt.in
@@ -131,7 +131,7 @@
 .. zephyr-keep-sorted-start re(^\.{2} \|.*\| replace:: :strong:`\w)
 
 .. |Sphinx| replace:: :strong:`Sphinx`
-.. |Sphinx_des| replace:: documentation generator based on `reStructuredText (RST) <reStructuredText Primer_>`_ files
+.. |Sphinx_des| replace:: documentation generator based on `reStructuredText (RST)`_ files
 .. |Sphinx_ver| replace:: @SPHINX_VERSION@
 
 .. |sphinx-autobuild| replace:: :strong:`sphinx-autobuild`
@@ -167,7 +167,7 @@
 .. |sphinx-togglebutton_ver| replace:: @SPHINX-TOGGLEBUTTON_VERSION@
 
 .. |sphinx_tsn_theme| replace:: :strong:`sphinx-tsn-theme`
-.. |sphinx_tsn_theme_des| replace:: `Sphinx theme <Sphinx HTML theming_>`_ for TiaC Systems Network (TSN) documentation
+.. |sphinx_tsn_theme_des| replace:: `Sphinx theme`_ for TiaC Systems Network (TSN) documentation
 .. |sphinx_tsn_theme_ver| replace:: @SPHINX-TSN-THEME_VERSION@
 
 .. |sphinxcontrib-mscgen| replace:: :strong:`sphinxcontrib-mscgen`
@@ -203,7 +203,7 @@
 .. |Pygments_ver| replace:: @PYGMENTS_VERSION@
 
 .. |docutils| replace:: :strong:`docutils`
-.. |docutils_des| replace:: modular system for processing `RST <reStructuredText Primer_>`_ documentation, backend of Sphinx_
+.. |docutils_des| replace:: modular system for processing RST_ documentation, backend of Sphinx_
 .. |docutils_ver| replace:: @DOCUTILS_VERSION@
 
 .. |doxmlparser| replace:: :strong:`doxmlparser`
@@ -257,7 +257,7 @@
 .. |Zephyr RTOS meta tool| replace:: :emphasis:`Zephyr RTOS meta tool`
 .. |west_pypa| replace:: :emphasis:`Zephyr RTOS meta tool` :command:`west` (PyPA)
 .. |west| replace:: :strong:`west`
-.. |west_des| replace:: The `Zephyr RTOS Project <Zephyr Project_>`_ meta-tool, a swiss-army knife command line tool
+.. |west_des| replace:: The `Zephyr RTOS Project`_ meta-tool, a swiss-army knife command line tool
 .. |west_ver| replace:: @WEST_VERSION@
 .. |west_min_ver| replace:: @WEST_VERSION_MINIMUM@
 .. |west_recommended_ver_linux| replace:: @WEST_VERSION_LINUX@

--- a/doc/cannectivity/conf.py
+++ b/doc/cannectivity/conf.py
@@ -44,7 +44,7 @@ sys.path.insert(0, str(BRIDLE_BASE / 'doc' / '_extensions'))
 sys.path.insert(0, str(ZEPHYR_BASE / 'doc' / '_extensions'))
 
 # Import all CANnectivity configuration, override as needed later
-conf = eval_config_file(str(CANNECTIVITY_BASE / 'doc' / 'conf.py'), tags)  # noqa: F821
+conf = eval_config_file(Path(CANNECTIVITY_BASE / 'doc' / 'conf.py'), tags)  # noqa: F821
 locals().update(conf)
 
 # Export CANNECTIVITY_BASE as environment variable to make autodoc for the

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -42,7 +42,7 @@
   "COMPONENTS_BY_VERSION": {
     "latest": {
       "bridle": "4.3.99",
-      "zephyr": "4.3.99",
+      "zephyr": "4.4.0",
       "cannectivity": "1.4.0-dev"
     },
     "4.3": {

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -37,7 +37,7 @@ ZEPHYR_WORKD = utils.get_builddir() / 'zephyr'
 sys.path.insert(0, str(BRIDLE_BASE / 'doc' / '_extensions'))
 
 # Import all Zephyr configuration, override as needed later
-conf = eval_config_file(str(ZEPHYR_BASE / 'doc' / 'conf.py'), tags)  # noqa: F821
+conf = eval_config_file(Path(ZEPHYR_BASE / 'doc' / 'conf.py'), tags)  # noqa: F821
 locals().update(conf)
 
 # Export ZEPHYR_BASE as environment variable to make autodoc for the

--- a/submanifests/zephyr.yml
+++ b/submanifests/zephyr.yml
@@ -1,6 +1,6 @@
 # The west submanifest file for Zephyr.
 #
-# Copyright (c) 2021-2025 TiaC Systems
+# Copyright (c) 2021-2026 TiaC Systems
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -35,7 +35,7 @@ manifest:
       path: zephyr
       remote: tiacsys
       repo-path: zephyr
-      revision: tiacsys/main
+      revision: tiacsys/v4.4.0
       clone-depth: 5000
       # import submodules from Zephyr manifest
       import:

--- a/zephyr/requirements-base.txt
+++ b/zephyr/requirements-base.txt
@@ -1,10 +1,14 @@
 # it's west
 # Keep the lowest version identical to the minimum required
 # in zephyr/cmake/modules/west.cmake
-west>=0.14.0,<1.5.0
+west>=0.14.0,<1.6.0
+
+# YAML validation. Is still used by west_commands.
+pykwalify>=1.8
 
 # Since zephyr/scripts/zephyr_module.py as an extension module for West
 # has replaced pykwalify with jsonschema, but West has not (yet) changed
 # its own dependency from pykwalify to jsonschema, the Python package
-# jsonschema must also be installed.
+# jsonschema must also be installed. For details see PR on West upstream:
+# https://github.com/zephyrproject-rtos/west/pull/904
 jsonschema

--- a/zephyr/requirements-build.txt
+++ b/zephyr/requirements-build.txt
@@ -8,13 +8,13 @@ pyelftools>=0.32
 # twister to parse YAMLs, by west, zephyr_module, ...
 PyYAML>=6.0
 
-# YAML validation. Used by zephyr_module.
+# YAML validation. Is still used by pylib and many helper scripts.
 pykwalify>=1.8
 
 # used by ci/check_compliance
 # zephyr-keep-sorted-start
-pylint<4.0,>=3.3
-regex>=2025.11
+pylint<5.0,>=3.3
+regex>=2026.4
 # zephyr-keep-sorted-stop
 
 # maybe used by signing with ECDSA for legacy nRF bootloaders

--- a/zephyr/requirements-doc.txt
+++ b/zephyr/requirements-doc.txt
@@ -1,20 +1,20 @@
 # zephyr-keep-sorted-start
-docutils<0.22,>=0.21
-doxmlparser~=1.15
-imagesize>=1.4
-pillow~=12.0
-pygments~=2.19,!=2.19.0
+docutils>=0.22
+doxmlparser~=1.16
+imagesize>=2.0
+pillow~=12.2
+pygments~=2.20
 sphinx-copybutton~=0.5
 sphinx-csv-filter~=0.4
-sphinx-filter-tabs~=1.2
+sphinx-filter-tabs~=1.5
 sphinx-notfound-page~=1.1
 sphinx-sitemap~=2.9
-sphinx-tabs~=3.4
-sphinx-togglebutton~=0.3
+sphinx-tabs~=3.5
+sphinx-togglebutton~=0.4
 sphinx-tsn-theme~=2024.11
 sphinxcontrib-mscgen~=0.6
-sphinxcontrib-programoutput~=0.18
-sphinxcontrib-svg2pdfconverter~=1.3
-sphinx~=8.2,<8.3
-sphobjinv~=2.3
+sphinxcontrib-programoutput~=0.19
+sphinxcontrib-svg2pdfconverter~=2.1
+sphinx~=9.1
+sphobjinv~=2.4
 # zephyr-keep-sorted-stop

--- a/zephyr/requirements-extras.txt
+++ b/zephyr/requirements-extras.txt
@@ -6,8 +6,8 @@ pymcuprog>=3.19
 # zephyr-keep-sorted-stop
 
 # used by west_commands
-pyocd>=0.36
+pyocd>=0.44
 pyserial>=3.5
 
 # used for west-command testing, also used by twister
-pytest<9.0,>=8.4
+pytest>=9.0


### PR DESCRIPTION
This is a maintenance PR to freeze upstream Zephyr release on v4.4.0 tag together wit the TSN patches needed for ongoing Bridle v4.3.99 development (preparation for Bridle v4.4.0 release).

It is related to #403 but many things still to do (check).