### PR TITLE
ci: github: qa-integration: disable test report annotation

### DIFF
--- a/.github/workflows/qa-acceptance.yml
+++ b/.github/workflows/qa-acceptance.yml
@@ -185,11 +185,11 @@ jobs:
           name: twister-acceptance.xml
           path: workspace/twister-out/twister.xml
 
-      - name: Convert integration test reports to annotations
-        if: always()
-        uses: mikepenz/action-junit-report@v6
-        with:
-          check_name: twister-report (acceptance)
-          report_paths: "**/twister-out/twister.xml"
-          require_tests: true
-          fail_on_failure: false
+#     - name: Convert integration test reports to annotations
+#       if: always()
+#       uses: mikepenz/action-junit-report@v6
+#       with:
+#         check_name: twister-report (acceptance)
+#         report_paths: "**/twister-out/twister.xml"
+#         require_tests: true
+#         fail_on_failure: false

--- a/.github/workflows/qa-integration-apps.yml
+++ b/.github/workflows/qa-integration-apps.yml
@@ -152,11 +152,11 @@ jobs:
           name: twister-samples.xml
           path: workspace/twister-out/twister.xml
 
-      - name: Convert integration test reports to annotations
-        if: always()
-        uses: mikepenz/action-junit-report@v6
-        with:
-          check_name: twister-report (samples)
-          report_paths: "**/twister-out/twister.xml"
-          require_tests: true
-          fail_on_failure: false
+#     - name: Convert integration test reports to annotations
+#       if: always()
+#       uses: mikepenz/action-junit-report@v6
+#       with:
+#         check_name: twister-report (samples)
+#         report_paths: "**/twister-out/twister.xml"
+#         require_tests: true
+#         fail_on_failure: false

--- a/.github/workflows/qa-integration-hil.yml
+++ b/.github/workflows/qa-integration-hil.yml
@@ -142,11 +142,11 @@ jobs:
           name: twister-targets.xml
           path: workspace/twister-out/twister.xml
 
-      - name: Convert integration test reports to annotations
-        if: always()
-        uses: mikepenz/action-junit-report@v6
-        with:
-          check_name: twister-report (${{ matrix.board }})
-          report_paths: "**/twister-out/twister.xml"
-          require_tests: true
-          fail_on_failure: false
+#     - name: Convert integration test reports to annotations
+#       if: always()
+#       uses: mikepenz/action-junit-report@v6
+#       with:
+#         check_name: twister-report (${{ matrix.board }})
+#         report_paths: "**/twister-out/twister.xml"
+#         require_tests: true
+#         fail_on_failure: false

--- a/.github/workflows/qa-integration.yml
+++ b/.github/workflows/qa-integration.yml
@@ -155,14 +155,14 @@ jobs:
           name: twister-samples.xml
           path: workspace/twister-out/twister.xml
 
-      - name: Convert integration test reports to annotations
-        if: always()
-        uses: mikepenz/action-junit-report@v6
-        with:
-          check_name: twister-report (samples)
-          report_paths: "**/twister-out/twister.xml"
-          require_tests: true
-          fail_on_failure: false
+  #   - name: Convert integration test reports to annotations
+  #     if: always()
+  #     uses: mikepenz/action-junit-report@v6
+  #     with:
+  #       check_name: twister-report (samples)
+  #       report_paths: "**/twister-out/twister.xml"
+  #       require_tests: true
+  #       fail_on_failure: false
 
   qa-tests-integration:
     name: Run integration tests from upstream
@@ -292,11 +292,11 @@ jobs:
           name: twister-tests.xml
           path: workspace/twister-out/twister.xml
 
-      - name: Convert integration test reports to annotations
-        if: always()
-        uses: mikepenz/action-junit-report@v6
-        with:
-          check_name: twister-report (tests)
-          report_paths: "**/twister-out/twister.xml"
-          require_tests: true
-          fail_on_failure: false
+#     - name: Convert integration test reports to annotations
+#       if: always()
+#       uses: mikepenz/action-junit-report@v6
+#       with:
+#         check_name: twister-report (tests)
+#         report_paths: "**/twister-out/twister.xml"
+#         require_tests: true
+#         fail_on_failure: false


### PR DESCRIPTION
Due to the rapidly increasing number of test samples against all supported platforms, the underlying build infrastructure is currently experiencing persistent failures in the GitHub action responsible for annotating the generated test reports. This is now leading to near-daily false-positive failures of the entire QA integration test chain due to the following error message, even at the end of successfully completed test runs:

    Error: timed out waiting for file … … …

Until a solution can be found, the processing and display of test results for the samples will be disabled, in the hope that fewer false alarms will be triggered from now on. The QA integration test chain should only fail and trigger an alert in the event of actual errors.