### PR TITLE
Fix broken QA integration tests and some more improvements to new separated boards

### DIFF
--- a/boards/cytron/maker_nano_rp2040/cytron_maker_nano_rp2040.dts
+++ b/boards/cytron/maker_nano_rp2040/cytron_maker_nano_rp2040.dts
@@ -181,8 +181,8 @@ zephyr_udc0: &usbd {
 		spi-zero-frame = <0xc0>;
 
 		chain-length = <2>;
-		color-mapping = <LED_COLOR_ID_RED
-				 LED_COLOR_ID_GREEN
+		color-mapping = <LED_COLOR_ID_GREEN
+				 LED_COLOR_ID_RED
 				 LED_COLOR_ID_BLUE>;
 	};
 };

--- a/boards/cytron/maker_nano_rp2040/doc/hardware.rsti
+++ b/boards/cytron/maker_nano_rp2040/doc/hardware.rsti
@@ -56,12 +56,13 @@ Main differences compared to the original Arduino Nano:
        - On-board :bbl:`BOOT` button
        - On-board :bbl:`USER` button
        - On-board :bbl:`1 Piezo` buzzer
+       - On-board :bbl:`2 RGB LED` (strip)
        - On-board :bbl:`13 LED`
        - :bbl:`22 GPIO` pins via :bbk:`edge pinout`
        - :bbl:`4 GPIO` pins via :bbk:`2 Qwiic/Grove connectors`
-       - :bbk:`1 UART` peripherals
-       - :bbk:`2 I2C` controllers
-       - :bbk:`1 SPI` controllers
+       - :bbl:`1 UART` peripherals
+       - :bbl:`2 I2C` controllers
+       - :bbl:`1 SPI` controllers
        - :bbl:`16 PWM` channels
        - :bbl:`4 ADC` analog inputs
        - 8 Programmable I/O (PIO) state machines for custom peripherals

--- a/boards/cytron/maker_nano_rp2040/doc/helloshell.rsti
+++ b/boards/cytron/maker_nano_rp2040/doc/helloshell.rsti
@@ -61,12 +61,12 @@ See also Bridle sample: :ref:`helloshell-sample`.
               DT node labels: reset
             - snippet_cdc_acm_console_uart (READY)
               DT node labels: snippet_cdc_acm_console_uart
+            - timer\ @\ 40054000 (READY)
+              DT node labels: timer
             - uart\ @\ 40034000 (READY)
               DT node labels: uart0 arduino_nano_serial grove_serial
             - watchdog\ @\ 40058000 (READY)
               DT node labels: wdt0
-            - timer\ @\ 40054000 (READY)
-              DT node labels: timer
             - dma\ @\ 50000000 (READY)
               DT node labels: dma
             - gpio-port\ @\ 0 (READY)
@@ -87,8 +87,14 @@ See also Bridle sample: :ref:`helloshell-sample`.
               DT node labels: vreg
             - rtc\ @\ 4005c000 (READY)
               DT node labels: rtc
+            - spi\ @\ 40040000 (READY)
+              DT node labels: spi1
+            - spi\ @\ 4003c000 (READY)
+              DT node labels: spi0 arduino_nano_spi
             - pwm_leds (READY)
               DT node labels: pwm_leds
+            - ws2812\ @\ 0 (READY)
+              DT node labels: led_strip
             - dietemp (READY)
               DT node labels: die_temp
 
@@ -116,17 +122,24 @@ See also Bridle sample: :ref:`helloshell-sample`.
          .. parsed-literal::
 
             :bgn:`uart:~$` **regulator vlist vreg**
-            0.800 V
-            0.850 V
-            0.900 V
-            0.950 V
-            1.000 V
-            1.050 V
-            1.100 V
-            1.150 V
-            1.200 V
-            1.250 V
-            1.300 V
+            0.800000 V
+            0.850000 V
+            0.900000 V
+            0.950000 V
+            1.000000 V
+            1.050000 V
+            1.100000 V
+            1.150000 V
+            1.200000 V
+            1.250000 V
+            1.300000 V
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **regulator vget vreg**
+            1.100000 V
 
       Trigger a power-of/on sequence:
 
@@ -149,6 +162,82 @@ See also Bridle sample: :ref:`helloshell-sample`.
             :bgn:`uart:~$` **hwinfo reset_cause**
             reset caused by:
             - power-on reset
+
+   .. group-tab:: LED Strip
+
+      Operate with the RGB digital LED strip :hwftlbl-led:`2 RGB`
+      at :rpi-pico-spi:`SPI1_TX`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip get_length led_strip**
+            ws2812@0 has 2 pixel(s)
+
+      Sett all LEDs to :brd:`RED`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070000 2**
+
+      Sett all LEDs to :byl:`YELLOW`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070700 2**
+
+      Sett all LEDs to :bgn:`GREEN`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000700 2**
+
+      Sett all LEDs to :bcy:`CYAN`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000707 2**
+
+      Sett all LEDs to :bbl:`BLUE`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000007 2**
+
+      Sett all LEDs to :bma:`MAGENTA`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070007 2**
+
+      Sett all LEDs to :bwt:`WHITE` (all on):
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070707 2**
+
+      Sett all LEDs to :bbk:`BLACK` (all off):
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000000 2**
 
    .. group-tab:: LED
 
@@ -394,15 +483,23 @@ See also Bridle sample: :ref:`helloshell-sample`.
 
       Operate with the channels:
 
-      - :rpi-pico-adc:`ADC2`, pulled up to :rpi-pico-vdd:`3V3`
-      - :rpi-pico-adc:`ADC3`, pulled down to :rpi-pico-gnd:`GND`
-      - on-chip temperature sensor on channel :rpi-pico-adc:`ADC4`
+      - :rpi-pico-adc:`ADC_CH2`, pulled up to :rpi-pico-vdd:`3V3`
+      - :rpi-pico-adc:`ADC_CH3`, pulled down to :rpi-pico-gnd:`GND`
+      - on-chip temperature sensor on channel :rpi-pico-adc:`ADC_CH4`
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
             :bgn:`uart:~$` **adc adc@4004c000 resolution 12**
+            :bgn:`uart:~$` **adc adc@4004c000 print**
+            adc\ @\ 4004c000:
+            Gain: 1
+            Reference: INTERNAL
+            Acquisition Time: 0
+            Channel ID: 0
+            Differential: 0
+            Resolution: 12
 
       .. container:: highlight highlight-console notranslate
 
@@ -511,13 +608,13 @@ See also Bridle sample: :ref:`helloshell-sample`.
    .. group-tab:: I2C
 
       The |Maker Nano RP2040| has no on-board I2C devices. For this example the
-      |Grove BMP280 Sensor|_ was connected to I2C0.
+      |Grove BMP280 Sensor|_ was connected to :rpi-pico-i2c-dfl:`I2C1`.
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c scan arduino_nano_i2c**
+            :bgn:`uart:~$` **i2c scan zephyr_i2c**
                  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
             00:             -- -- -- -- -- -- -- -- -- -- -- --
             10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -527,7 +624,7 @@ See also Bridle sample: :ref:`helloshell-sample`.
             50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             70: -- -- -- -- -- -- -- 77
-            1 devices found on arduino_nano_i2c
+            1 devices found on zephyr_i2c
 
       The I2C address ``0x77`` is a Bosch BMP280 Air Pressure Sensor and their
       Chip-ID can read from register ``0xd0``. The Chip-ID must be ``0x58``:
@@ -536,7 +633,7 @@ See also Bridle sample: :ref:`helloshell-sample`.
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c read_byte arduino_nano_i2c 77 d0**
+            :bgn:`uart:~$` **i2c read_byte zephyr_i2c 77 d0**
             Output: 0x58
 
    .. group-tab:: Sensors
@@ -555,4 +652,4 @@ See also Bridle sample: :ref:`helloshell-sample`.
          .. parsed-literal::
 
             :bgn:`uart:~$` **sensor get dietemp**
-            channel type=12(die_temp) index=0 shift=5 num_samples=1 value=140591584104ns (27.581056)
+            channel type=12(die_temp) index=0 shift=6 num_samples=1 value=140591584104ns (27.581056)

--- a/boards/cytron/maker_nano_rp2040/doc/pinouts.rsti
+++ b/boards/cytron/maker_nano_rp2040/doc/pinouts.rsti
@@ -55,8 +55,8 @@ digital signal lines. Also all IO voltage levels are limited to 3.3V only.
        - | :rpi-pico-pin:`20` :rpi-pico-i2c-dfl:`I2C1_SCL` : GP27 (PWM11)
        - | :rpi-pico-pin:`21` :rpi-pico-adc:`ADC_CH2` : GP28 (PWM12)
        - | :rpi-pico-pin:`22` :rpi-pico-adc:`ADC_CH3` : GP29 (PWM13)
-       - | :rpi-pico-pin:`23` :rpi-pico-i2c-dfl:`I2C0_SDA` : GP12 (PWM12)
-       - | :rpi-pico-pin:`24` :rpi-pico-i2c-dfl:`I2C0_SCL` : GP13 (PWM13)
+       - | :rpi-pico-pin:`23` :rpi-pico-i2c:`I2C0_SDA` : GP12 (PWM12)
+       - | :rpi-pico-pin:`24` :rpi-pico-i2c:`I2C0_SCL` : GP13 (PWM13)
        - | :rpi-pico-pin:`25` PIO/PWM : :rpi-pico-pio:`GP14` :rpi-pico-pwm:`PWM14`
        - | :rpi-pico-pin:`26` PIO/PWM : :rpi-pico-pio:`GP15` :rpi-pico-pwm:`PWM15`
        - | :rpi-pico-pin:`27` :rpi-pico-vdd:`5V(OUT)`
@@ -96,7 +96,7 @@ digital signal lines. Also all IO voltage levels are limited to 3.3V only.
 
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-led:`BLUE` : :rpi-pico-pio:`GP9` :rpi-pico-pwm:`PWM9`
        - | :rpi-pico-pin-nc:`nc` :rpi-pico-sys:`n.c.` : GP10 (PWM10)
-       - | :rpi-pico-pin-nc:`nc` :hwftlbl-led:`RGB` :rpi-pico-spi:`SPI1_TX` : GP11
+       - | :rpi-pico-pin-nc:`nc` :hwftlbl-led:`RGB` : :rpi-pico-spi:`SPI1_TX` : GP11
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-btn:`USER` : :rpi-pico-pio:`GP20` (PWM4)
        - | :rpi-pico-pin-nc:`nc` :rpi-pico-sys:`n.c.` : GP21 (PWM5)
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-spk:`PIEZO` : :rpi-pico-pio:`GP22` :rpi-pico-pwm:`PWM6`

--- a/boards/cytron/maker_pi_rp2040/cytron_maker_pi_rp2040.dts
+++ b/boards/cytron/maker_pi_rp2040/cytron_maker_pi_rp2040.dts
@@ -238,8 +238,8 @@ zephyr_udc0: &usbd {
 			status = "okay";
 
 			chain-length = <2>;
-			color-mapping = <LED_COLOR_ID_RED
-					 LED_COLOR_ID_GREEN
+			color-mapping = <LED_COLOR_ID_GREEN
+					 LED_COLOR_ID_RED
 					 LED_COLOR_ID_BLUE>;
 
 			/* PIO0:OUT @ GP18 and Tbit = 1.25 us / 10 */

--- a/boards/cytron/maker_pi_rp2040/doc/hardware.rsti
+++ b/boards/cytron/maker_pi_rp2040/doc/hardware.rsti
@@ -64,11 +64,12 @@ power sources can all be controlled with the power on/off switch on-board.
        - On-board :bbl:`BOOT` button
        - On-board :bbl:`2 USER` button
        - On-board :bbl:`1 Piezo` buzzer
+       - On-board :bbl:`2 RGB LED` (strip)
        - On-board :bbl:`13 LED`
        - :bbl:`13 GPIO` pins via :bbk:`7 Grove connectors`
-       - :bbk:`1 UART` peripherals
-       - :bbk:`2 I2C` controllers
-       - :bbk:`1 SPI` controllers
+       - :bbl:`1 UART` peripherals
+       - :bbl:`2 I2C` controllers
+       - :bbl:`1 SPI` controllers
        - :bbl:`8 PWM` channels
        - :bbl:`3 ADC` analog inputs
        - 8 Programmable I/O (PIO) state machines for custom peripherals

--- a/boards/cytron/maker_pi_rp2040/doc/helloshell.rsti
+++ b/boards/cytron/maker_pi_rp2040/doc/helloshell.rsti
@@ -61,12 +61,12 @@ See also Bridle sample: :ref:`helloshell-sample`.
               DT node labels: reset
             - snippet_cdc_acm_console_uart (READY)
               DT node labels: snippet_cdc_acm_console_uart
+            - timer\ @\ 40054000 (READY)
+              DT node labels: timer
             - uart\ @\ 40034000 (READY)
               DT node labels: uart0 grove_serial
             - watchdog\ @\ 40058000 (READY)
               DT node labels: wdt0
-            - timer\ @\ 40054000 (READY)
-              DT node labels: timer
             - pio\ @\ 50200000 (READY)
               DT node labels: ((pio_hw_t \*)0x50200000u)
             - dma\ @\ 50000000 (READY)
@@ -89,6 +89,9 @@ See also Bridle sample: :ref:`helloshell-sample`.
               DT node labels: rtc
             - pwm_leds (READY)
               DT node labels: pwm_leds
+            - pio-ws2812 (READY)
+            - ws2812 (READY)
+              DT node labels: led_strip
             - dietemp (READY)
               DT node labels: die_temp
 
@@ -116,17 +119,24 @@ See also Bridle sample: :ref:`helloshell-sample`.
          .. parsed-literal::
 
             :bgn:`uart:~$` **regulator vlist vreg**
-            0.800 V
-            0.850 V
-            0.900 V
-            0.950 V
-            1.000 V
-            1.050 V
-            1.100 V
-            1.150 V
-            1.200 V
-            1.250 V
-            1.300 V
+            0.800000 V
+            0.850000 V
+            0.900000 V
+            0.950000 V
+            1.000000 V
+            1.050000 V
+            1.100000 V
+            1.150000 V
+            1.200000 V
+            1.250000 V
+            1.300000 V
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **regulator vget vreg**
+            1.100000 V
 
       Trigger a power-of/on sequence:
 
@@ -149,6 +159,82 @@ See also Bridle sample: :ref:`helloshell-sample`.
             :bgn:`uart:~$` **hwinfo reset_cause**
             reset caused by:
             - power-on reset
+
+   .. group-tab:: LED Strip
+
+      Operate with the RGB digital LED strip :hwftlbl-led:`2 RGB`
+      at :rpi-pico-pio:`PIO0` / :rpi-pico-pio:`GP18`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip get_length led_strip**
+            ws2812 has 2 pixel(s)
+
+      Sett all LEDs to :brd:`RED`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070000 2**
+
+      Sett all LEDs to :byl:`YELLOW`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070700 2**
+
+      Sett all LEDs to :bgn:`GREEN`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000700 2**
+
+      Sett all LEDs to :bcy:`CYAN`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000707 2**
+
+      Sett all LEDs to :bbl:`BLUE`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000007 2**
+
+      Sett all LEDs to :bma:`MAGENTA`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070007 2**
+
+      Sett all LEDs to :bwt:`WHITE` (all on):
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070707 2**
+
+      Sett all LEDs to :bbk:`BLACK` (all off):
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000000 2**
 
    .. group-tab:: LED
 
@@ -409,16 +495,24 @@ See also Bridle sample: :ref:`helloshell-sample`.
 
       Operate with the channels:
 
-      - :rpi-pico-adc:`ADC0`, pulled up to :rpi-pico-vdd:`3V3`
-      - :rpi-pico-adc:`ADC1`, pulled down to :rpi-pico-gnd:`GND`
-      - :rpi-pico-adc:`ADC3`, on-board :rpi-pico-vdd:`VM/2` voltage monitoring
-      - on-chip temperature sensor on channel :rpi-pico-adc:`ADC4`
+      - :rpi-pico-adc:`ADC_CH0`, pulled up to :rpi-pico-vdd:`3V3`
+      - :rpi-pico-adc:`ADC_CH1`, pulled down to :rpi-pico-gnd:`GND`
+      - :rpi-pico-adc:`ADC_CH3`, on-board :rpi-pico-vdd:`VM/2` voltage monitoring
+      - on-chip temperature sensor on channel :rpi-pico-adc:`ADC_CH4`
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
             :bgn:`uart:~$` **adc adc@4004c000 resolution 12**
+            :bgn:`uart:~$` **adc adc@4004c000 print**
+            adc\ @\ 4004c000:
+            Gain: 1
+            Reference: INTERNAL
+            Acquisition Time: 0
+            Channel ID: 0
+            Differential: 0
+            Resolution: 12
 
       .. container:: highlight highlight-console notranslate
 
@@ -534,7 +628,7 @@ See also Bridle sample: :ref:`helloshell-sample`.
    .. group-tab:: I2C
 
       The |Maker Pi RP2040| has no on-board I2C devices. For this example the
-      |Grove BMP280 Sensor|_ was connected.
+      |Grove BMP280 Sensor|_ was connected to :rpi-pico-i2c-dfl:`I2C0`.
 
       .. container:: highlight highlight-console notranslate
 
@@ -578,4 +672,4 @@ See also Bridle sample: :ref:`helloshell-sample`.
          .. parsed-literal::
 
             :bgn:`uart:~$` **sensor get dietemp**
-            channel type=12(die_temp) index=0 shift=5 num_samples=1 value=56376680956ns (29.324229)
+            channel type=12(die_temp) index=0 shift=6 num_samples=1 value=56376680956ns (29.324229)

--- a/boards/cytron/maker_pi_rp2040/doc/pinouts.rsti
+++ b/boards/cytron/maker_pi_rp2040/doc/pinouts.rsti
@@ -15,7 +15,7 @@ be used on-board as analog channel A3 for VM/2 voltage monitoring per default.
           :hwftlbl-pio:`2 (13)`
           :hwftlbl-pwm:`2 (8)`
           :hwftlbl-adc:`3`
-          :hwftlbl-i2c:`2`
+          :hwftlbl-i2c:`1`
           :hwftlbl-spi:`1`
           :hwftlbl-uart:`1`
 
@@ -108,7 +108,7 @@ be used on-board as analog channel A3 for VM/2 voltage monitoring per default.
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-act:`SRVM2` : :rpi-pico-pio:`GP13` :rpi-pico-pwm:`PWM13`
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-act:`SRVM3` : :rpi-pico-pio:`GP14` :rpi-pico-pwm:`PWM14`
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-act:`SRVM4` : :rpi-pico-pio:`GP15` :rpi-pico-pwm:`PWM15`
-       - | :rpi-pico-pin-nc:`nc` :hwftlbl-led:`RGB` :rpi-pico-pio:`PIO0` : GP18
+       - | :rpi-pico-pin-nc:`nc` :hwftlbl-led:`RGB` : :rpi-pico-pio:`PIO0` : GP18
        - | :rpi-pico-pin-nc:`nc` :rpi-pico-sys:`n.c.` : GP19 (PWM3)
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-btn:`USER` : :rpi-pico-pio:`GP20` (PWM4)
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-btn:`USER` : :rpi-pico-pio:`GP21` (PWM5)

--- a/boards/cytron/motion_2350_pro/cytron_motion_2350_pro.dtsi
+++ b/boards/cytron/motion_2350_pro/cytron_motion_2350_pro.dtsi
@@ -232,8 +232,8 @@ zephyr_udc0: &usbd {
 		spi-zero-frame = <0xc0>;
 
 		chain-length = <2>;
-		color-mapping = <LED_COLOR_ID_RED
-				 LED_COLOR_ID_GREEN
+		color-mapping = <LED_COLOR_ID_GREEN
+				 LED_COLOR_ID_RED
 				 LED_COLOR_ID_BLUE>;
 	};
 };

--- a/boards/cytron/motion_2350_pro/doc/hardware.rsti
+++ b/boards/cytron/motion_2350_pro/doc/hardware.rsti
@@ -67,13 +67,14 @@ switch on-board (with MOSFET shock-proof circuit).
        - On-board :bbl:`BOOT` button
        - On-board :bbl:`2 USER` button
        - On-board :bbl:`1 Piezo` buzzer
+       - On-board :bbl:`2 RGB LED` (strip)
        - On-board :bbl:`24 LED`
        - :bbl:`8 GPIO` pins via :bbk:`3.3V generic pin header`
        - :bbl:`8 GPIO` pins via :bbk:`5.0V servo pin header`
        - :bbl:`6 GPIO` pins via :bbk:`3 Grove connectors`
-       - :bbk:`1 UART` peripherals
-       - :bbk:`2 I2C` controllers
-       - :bbk:`1 SPI` controllers
+       - :bbl:`1 UART` peripherals
+       - :bbl:`2 I2C` controllers
+       - :bbl:`1 SPI` controllers
        - :bbl:`8 PWM` channels
        - :bbl:`4 ADC` analog inputs
        - 12 Programmable I/O (PIO) state machines for custom peripherals

--- a/boards/cytron/motion_2350_pro/doc/helloshell.rsti
+++ b/boards/cytron/motion_2350_pro/doc/helloshell.rsti
@@ -76,14 +76,14 @@ See also Bridle sample: :ref:`helloshell-sample`.
               DT node labels: reset
             - snippet_cdc_acm_console_uart (READY)
               DT node labels: snippet_cdc_acm_console_uart
-            - uart\ @\ 40070000 (READY)
-              DT node labels: uart0 grove_serial
-            - watchdog\ @\ 400d8000 (READY)
-              DT node labels: wdt0
             - timer\ @\ 400b8000 (READY)
               DT node labels: timer1
             - timer\ @\ 400b0000 (READY)
               DT node labels: timer0
+            - uart\ @\ 40070000 (READY)
+              DT node labels: uart0 grove_serial
+            - watchdog\ @\ 400d8000 (READY)
+              DT node labels: wdt0
             - dma\ @\ 50000000 (READY)
               DT node labels: dma
             - gpio-port\ @\ 0 (READY)
@@ -95,13 +95,17 @@ See also Bridle sample: :ref:`helloshell-sample`.
             - flash-controller\ @\ 400d0000 (READY)
               DT node labels: qmi
             - i2c\ @\ 40090000 (READY)
-              DT node labels: i2c0 zephyr_i2c grove_i2c
+              DT node labels: i2c0 zephyr_i2c stemma_i2c qwiic_i2c grove_i2c
             - pwm\ @\ 400a8000 (READY)
               DT node labels: pwm grove_pwm_d16 grove_pwm_d17 grove_pwm_d26 grove_pwm_d27 grove_pwm_d28 grove_pwm_d29
             - vreg\ @\ 40100000 (READY)
               DT node labels: vreg
+            - spi\ @\ 40080000 (READY)
+              DT node labels: spi0
             - pwm_leds (READY)
               DT node labels: pwm_leds
+            - ws2812\ @\ 0 (READY)
+              DT node labels: led_strip
             - dietemp (READY)
               DT node labels: die_temp
 
@@ -121,14 +125,14 @@ See also Bridle sample: :ref:`helloshell-sample`.
               DT node labels: intc
             - snippet_cdc_acm_console_uart (READY)
               DT node labels: snippet_cdc_acm_console_uart
-            - uart\ @\ 40070000 (READY)
-              DT node labels: uart0 grove_serial
-            - watchdog\ @\ 400d8000 (READY)
-              DT node labels: wdt0
             - timer\ @\ 400b8000 (READY)
               DT node labels: timer1
             - timer\ @\ 400b0000 (READY)
               DT node labels: timer0
+            - uart\ @\ 40070000 (READY)
+              DT node labels: uart0 grove_serial
+            - watchdog\ @\ 400d8000 (READY)
+              DT node labels: wdt0
             - dma\ @\ 50000000 (READY)
               DT node labels: dma
             - gpio-port\ @\ 0 (READY)
@@ -140,13 +144,17 @@ See also Bridle sample: :ref:`helloshell-sample`.
             - flash-controller\ @\ 400d0000 (READY)
               DT node labels: qmi
             - i2c\ @\ 40090000 (READY)
-              DT node labels: i2c0 zephyr_i2c grove_i2c
+              DT node labels: i2c0 zephyr_i2c stemma_i2c qwiic_i2c grove_i2c
             - pwm\ @\ 400a8000 (READY)
               DT node labels: pwm grove_pwm_d16 grove_pwm_d17 grove_pwm_d26 grove_pwm_d27 grove_pwm_d28 grove_pwm_d29
             - vreg\ @\ 40100000 (READY)
               DT node labels: vreg
+            - spi\ @\ 40080000 (READY)
+              DT node labels: spi0
             - pwm_leds (READY)
               DT node labels: pwm_leds
+            - ws2812\ @\ 0 (READY)
+              DT node labels: led_strip
             - dietemp (READY)
               DT node labels: die_temp
 
@@ -235,6 +243,82 @@ See also Bridle sample: :ref:`helloshell-sample`.
                :bgn:`uart:~$` **hwinfo reset_cause**
                reset caused by:
                - power-on reset
+
+   .. group-tab:: LED Strip
+
+      Operate with the RGB digital LED strip :hwftlbl-led:`2 RGB`
+      at :rpi-pico-spi:`SPI0_TX`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip get_length led_strip**
+            ws2812@0 has 2 pixel(s)
+
+      Sett all LEDs to :brd:`RED`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070000 2**
+
+      Sett all LEDs to :byl:`YELLOW`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070700 2**
+
+      Sett all LEDs to :bgn:`GREEN`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000700 2**
+
+      Sett all LEDs to :bcy:`CYAN`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000707 2**
+
+      Sett all LEDs to :bbl:`BLUE`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000007 2**
+
+      Sett all LEDs to :bma:`MAGENTA`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070007 2**
+
+      Sett all LEDs to :bwt:`WHITE` (all on):
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070707 2**
+
+      Sett all LEDs to :bbk:`BLACK` (all off):
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000000 2**
 
    .. group-tab:: LED
 
@@ -495,17 +579,25 @@ See also Bridle sample: :ref:`helloshell-sample`.
 
       Operate with the channels:
 
-      - :rpi-pico-adc:`ADC0`, pulled up to :rpi-pico-vdd:`3V3`
-      - :rpi-pico-adc:`ADC1`, pulled down to :rpi-pico-gnd:`GND`
-      - :rpi-pico-adc:`ADC3`, on-board :rpi-pico-vdd:`VIN/6.1`
+      - :rpi-pico-adc:`ADC_CH0`, pulled up to :rpi-pico-vdd:`3V3`
+      - :rpi-pico-adc:`ADC_CH1`, pulled down to :rpi-pico-gnd:`GND`
+      - :rpi-pico-adc:`ADC_CH3`, on-board :rpi-pico-vdd:`VIN/6.1`
         voltage monitoring (optional, when solder bridge was closed)
-      - on-chip temperature sensor on channel :rpi-pico-adc:`ADC4`
+      - on-chip temperature sensor on channel :rpi-pico-adc:`ADC_CH4`
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
             :bgn:`uart:~$` **adc adc@400a0000 resolution 12**
+            :bgn:`uart:~$` **adc adc@400a0000 print**
+            adc\ @\ 400a0000:
+            Gain: 1
+            Reference: INTERNAL
+            Acquisition Time: 0
+            Channel ID: 0
+            Differential: 0
+            Resolution: 12
 
       .. container:: highlight highlight-console notranslate
 
@@ -608,13 +700,13 @@ See also Bridle sample: :ref:`helloshell-sample`.
    .. group-tab:: I2C
 
       The |MOTION 2350 Pro| has no on-board I2C devices. For this example the
-      |Grove BMP280 Sensor|_ was connected.
+      |Grove BMP280 Sensor|_ was connected to :rpi-pico-i2c-dfl:`I2C0`.
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c scan grove_i2c**
+            :bgn:`uart:~$` **i2c scan zephyr_i2c**
                  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
             00:             -- -- -- -- -- -- -- -- -- -- -- --
             10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -624,7 +716,7 @@ See also Bridle sample: :ref:`helloshell-sample`.
             50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             70: -- -- -- -- -- -- -- 77
-            1 devices found on grove_i2c
+            1 devices found on zephyr_i2c
 
       The I2C address ``0x77`` is a Bosch BMP280 Air Pressure Sensor and their
       Chip-ID can read from register ``0xd0``. The Chip-ID must be ``0x58``:
@@ -633,7 +725,7 @@ See also Bridle sample: :ref:`helloshell-sample`.
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c read_byte grove_i2c 77 d0**
+            :bgn:`uart:~$` **i2c read_byte zephyr_i2c 77 d0**
             Output: 0x58
 
    .. group-tab:: Sensors
@@ -652,4 +744,4 @@ See also Bridle sample: :ref:`helloshell-sample`.
          .. parsed-literal::
 
             :bgn:`uart:~$` **sensor get dietemp**
-            channel type=12(die_temp) index=0 shift=5 num_samples=1 value=14655375226ns (29.324229)
+            channel type=12(die_temp) index=0 shift=6 num_samples=1 value=14655375226ns (29.324229)

--- a/boards/cytron/motion_2350_pro/doc/pinouts.rsti
+++ b/boards/cytron/motion_2350_pro/doc/pinouts.rsti
@@ -13,11 +13,11 @@ VIN/6.1 voltage monitoring.
      - .. rubric:: Pinout
 
    * - :on-edge(Qwiic):
-          :hwftlbl-pio:`2 (6)`
-          :hwftlbl-pwm:`2 (6)`
-          :hwftlbl-adc:`3`
-          :hwftlbl-i2c:`2`
-          :hwftlbl-spi:`1`
+          :hwftlbl-pio:`(6)`
+          :hwftlbl-pwm:`(6)`
+          :hwftlbl-adc:`2 (3)`
+          :hwftlbl-i2c:`1 (2)`
+          :hwftlbl-spi:`(1)`
           :hwftlbl-uart:`1`
 
        :on-board:
@@ -143,7 +143,7 @@ VIN/6.1 voltage monitoring.
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-btn:`USER` : :rpi-pico-pio:`GP20` (PWM4)
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-btn:`USER` : :rpi-pico-pio:`GP21` (PWM5)
        - | :rpi-pico-pin-nc:`nc` :hwftlbl-spk:`PIEZO` : :rpi-pico-pio:`GP22` :rpi-pico-pwm:`PWM6`
-       - | :rpi-pico-pin-nc:`nc` :hwftlbl-led:`RGB` :rpi-pico-spi:`SPI0_TX` : GP23
+       - | :rpi-pico-pin-nc:`nc` :hwftlbl-led:`RGB` : :rpi-pico-spi:`SPI0_TX` : GP23
        - | :rpi-pico-pin-nc:`nc` :rpi-pico-adc:`ADC_CH3` : GP29 (PWM13)
          | :rpi-pico-pin-nc:`nc` on-board :rpi-pico-vdd:`VIN/6.1` monitoring
        - | :rpi-pico-pin-nc:`nc` :rpi-pico-sys:`3V3` : :rpi-pico-adc:`ADC_VREF`

--- a/boards/jsed/picoboy/doc/hardware.rsti
+++ b/boards/jsed/picoboy/doc/hardware.rsti
@@ -51,13 +51,13 @@ RP2040 development board.
        - On-board :bbl:`3 User LEDs`
        - On-board :bbl:`1.3-inch 128×64 pixels OLED`, monochrome white (serial)
        - On-board :bbl:`1 passive magnetic speaker`
-       - On-board :bbl:`1 acceleration sensor`, 3-axis MEMS (digital)
+       - On-board :bbl:`3-DOF IMU sensor`
        - :bbk:`1 RST signal to OLED controller`
        - :bbk:`1 C/D signal to OLED controller`
        - :bbk:`1 I2C` controller for acceleration sensor
        - :bbk:`1 SPI` controller for OLED
-       - :bbl:`4 PWM` channels for LEDs and speaker
-       - :bbl:`4 ADC` analog inputs
+       - :bbk:`4 PWM` channels for LEDs and speaker
+       - :bbk:`4 ADC` analog inputs
        - 8 Programmable I/O (PIO) state machines for custom peripherals
        - 1 Watchdog timer peripheral
        - 1 Temperature sensor on-chip

--- a/boards/jsed/picoboy/doc/helloshell_console.rsti
+++ b/boards/jsed/picoboy/doc/helloshell_console.rsti
@@ -48,10 +48,10 @@
               DT node labels: reset
             - cdc_acm_console_uart (READY)
               DT node labels: cdc_acm_console_uart
-            - watchdog\ @\ 40058000 (READY)
-              DT node labels: wdt0
             - timer\ @\ 40054000 (READY)
               DT node labels: timer
+            - watchdog\ @\ 40058000 (READY)
+              DT node labels: wdt0
             - dma\ @\ 50000000 (READY)
               DT node labels: dma
             - gpio-port\ @\ 0 (READY)
@@ -101,17 +101,24 @@
          .. parsed-literal::
 
             :bgn:`uart:~$` **regulator vlist vreg**
-            0.800 V
-            0.850 V
-            0.900 V
-            0.950 V
-            1.000 V
-            1.050 V
-            1.100 V
-            1.150 V
-            1.200 V
-            1.250 V
-            1.300 V
+            0.800000 V
+            0.850000 V
+            0.900000 V
+            0.950000 V
+            1.000000 V
+            1.050000 V
+            1.100000 V
+            1.150000 V
+            1.200000 V
+            1.250000 V
+            1.300000 V
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **regulator vget vreg**
+            1.100000 V
 
       Trigger a power-of/on sequence:
 
@@ -348,11 +355,11 @@
 
       Operate with the channels:
 
-         - :rpi-pico-adc:`ADC0`, pulled to unknown voltage level
-         - :rpi-pico-adc:`ADC1`, pulled to unknown voltage level
-         - :rpi-pico-adc:`ADC2`, pulled to unknown voltage level
-         - :rpi-pico-adc:`ADC3`, pulled to unknown voltage level
-         - on-chip temperature sensor on channel :rpi-pico-adc:`ADC4`
+         - :rpi-pico-adc:`ADC_CH0`, pulled to unknown voltage level
+         - :rpi-pico-adc:`ADC_CH1`, pulled to unknown voltage level
+         - :rpi-pico-adc:`ADC_CH2`, pulled to unknown voltage level
+         - :rpi-pico-adc:`ADC_CH3`, pulled to unknown voltage level
+         - on-chip temperature sensor on channel :rpi-pico-adc:`ADC_CH4`
 
       .. container:: highlight highlight-console notranslate
 
@@ -488,7 +495,8 @@
 
    .. group-tab:: I2C
 
-      The |PicoBoy| has the on-board acceleration sensor connected on I2C0.
+      The |PicoBoy| has the on-board acceleration sensor
+      connected on :rpi-pico-i2c:`I2C0`.
 
       .. container:: highlight highlight-console notranslate
 
@@ -534,7 +542,7 @@
          .. parsed-literal::
 
             :bgn:`uart:~$` **sensor get dietemp**
-            channel type=12(die_temp) index=0 shift=5 num_samples=1 value=96691043776ns (29.905286)
+            channel type=12(die_temp) index=0 shift=6 num_samples=1 value=96691043776ns (29.905286)
 
       .. rubric:: on-board 3-axis accelerometer
 

--- a/boards/jsed/picoboy_color/doc/hardware.rsti
+++ b/boards/jsed/picoboy_color/doc/hardware.rsti
@@ -56,8 +56,8 @@ RP2040 development board.
        - :bbk:`1 C/D signal to LCD controller`
        - :bbk:`1 SPI` controller for LCD
        - :bbk:`1 I2C` controller for external sensor
-       - :bbl:`5 PWM` channels for LEDs, LCD backlight and speaker
-       - :bbl:`1 ADC` analog inputs
+       - :bbk:`5 PWM` channels for LEDs, LCD backlight and speaker
+       - :bbk:`1 ADC` analog inputs
        - 8 Programmable I/O (PIO) state machines for custom peripherals
        - 1 Watchdog timer peripheral
        - 1 Temperature sensor on-chip

--- a/boards/jsed/picoboy_color/doc/helloshell_console.rsti
+++ b/boards/jsed/picoboy_color/doc/helloshell_console.rsti
@@ -48,10 +48,10 @@
               DT node labels: reset
             - cdc_acm_console_uart (READY)
               DT node labels: cdc_acm_console_uart
-            - watchdog\ @\ 40058000 (READY)
-              DT node labels: wdt0
             - timer\ @\ 40054000 (READY)
               DT node labels: timer
+            - watchdog\ @\ 40058000 (READY)
+              DT node labels: wdt0
             - dma\ @\ 50000000 (READY)
               DT node labels: dma
             - gpio-port\ @\ 0 (READY)
@@ -63,7 +63,7 @@
             - flash-controller\ @\ 18000000 (READY)
               DT node labels: ssi
             - i2c\ @\ 40044000 (READY)
-              DT node labels: i2c0
+              DT node labels: i2c0 zephyr_i2c
             - pwm\ @\ 40050000 (READY)
               DT node labels: pwm
             - vreg\ @\ 40064000 (READY)
@@ -101,17 +101,24 @@
          .. parsed-literal::
 
             :bgn:`uart:~$` **regulator vlist vreg**
-            0.800 V
-            0.850 V
-            0.900 V
-            0.950 V
-            1.000 V
-            1.050 V
-            1.100 V
-            1.150 V
-            1.200 V
-            1.250 V
-            1.300 V
+            0.800000 V
+            0.850000 V
+            0.900000 V
+            0.950000 V
+            1.000000 V
+            1.050000 V
+            1.100000 V
+            1.150000 V
+            1.200000 V
+            1.250000 V
+            1.300000 V
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **regulator vget vreg**
+            1.100000 V
 
       Trigger a power-of/on sequence:
 
@@ -362,8 +369,8 @@
 
       Operate with the channels:
 
-         - :rpi-pico-adc:`ADC3`, pulled to unknown voltage level
-         - on-chip temperature sensor on channel :rpi-pico-adc:`ADC4`
+         - :rpi-pico-adc:`ADC_CH3`, pulled to unknown voltage level
+         - on-chip temperature sensor on channel :rpi-pico-adc:`ADC_CH4`
 
       .. container:: highlight highlight-console notranslate
 
@@ -479,13 +486,13 @@
    .. group-tab:: I2C
 
       The |PicoBoy Color| has no on-board I2C devices. For this example the
-      |Grove BMP280 Sensor|_ was connected.
+      |Grove BMP280 Sensor|_ was connected to :rpi-pico-i2c-dfl:`I2C0`.
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c scan i2c0**
+            :bgn:`uart:~$` **i2c scan zephyr_i2c**
                  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
             00:             -- -- -- -- -- -- -- -- -- -- -- --
             10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -495,7 +502,7 @@
             50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             70: -- -- -- -- -- -- -- 77
-            1 devices found on i2c0
+            1 devices found on zephyr_i2c
 
       The I2C address ``0x77`` is a Bosch BMP280 Air Pressure Sensor and their
       Chip-ID can read from register ``0xd0``. The Chip-ID must be ``0x58``:
@@ -504,7 +511,7 @@
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c read_byte i2c0 77 d0**
+            :bgn:`uart:~$` **i2c read_byte zephyr_i2c 77 d0**
             Output: 0x58
 
    .. group-tab:: Sensors

--- a/boards/jsed/picoboy_color/doc/pinouts.rsti
+++ b/boards/jsed/picoboy_color/doc/pinouts.rsti
@@ -83,10 +83,10 @@
              .. rubric:: Sensors via solder pads
              .. rst-class:: rst-columns edge-pinout
 
-             - | :rpi-pico-i2c-dfl:`I2C0_SDA` : :rpi-pico-uart:`UART1_TX` : GP20 (PWM4)
+             - | :rpi-pico-i2c-dfl:`I2C0_SDA` : :rpi-pico-uart:`(UART1_TX)` : GP20 (PWM4)
                | on-board solder pads i/f data :rpi-pico-sys:`I2C_SDA`
                | on-board solder pads i/f data :rpi-pico-sys:`UART_TX`
-             - | :rpi-pico-i2c-dfl:`I2C0_SCL` : :rpi-pico-uart:`UART1_RX` : GP21 (PWM5)
+             - | :rpi-pico-i2c-dfl:`I2C0_SCL` : :rpi-pico-uart:`(UART1_RX)` : GP21 (PWM5)
                | on-board solder pads i/f clock :rpi-pico-sys:`I2C_SCL`
                | on-board solder pads i/f data :rpi-pico-sys:`UART_RX`
 

--- a/boards/jsed/picoboy_color/picoboy_color.dts
+++ b/boards/jsed/picoboy_color/picoboy_color.dts
@@ -309,6 +309,8 @@ lcd_panel: &st7789v_240x280 {};
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
+zephyr_i2c: &i2c0 {};
+
 &pwm {
 	status = "okay";
 	pinctrl-0 = <&pwm_default>;

--- a/boards/jsed/picoboy_color_plus/doc/hardware.rsti
+++ b/boards/jsed/picoboy_color_plus/doc/hardware.rsti
@@ -57,12 +57,13 @@ The `PicoBoy Color Plus <PicoBoy Color Plus Origin_>`_ is a
        - On-board :bbl:`1 User RGB LED`
        - On-board :bbl:`1.69-inch 240×280 pixels LCD`, 65K colorful IPS (serial)
        - On-board :bbl:`1 passive magnetic speaker`
+       - On-board :bbl:`3-DOF IMU sensor`
        - :bbk:`1 RST signal to LCD controller`
        - :bbk:`1 C/D signal to LCD controller`
        - :bbk:`1 SPI` controller for LCD
        - :bbk:`1 I2C` controller for external sensor
-       - :bbl:`5 PWM` channels for LEDs, LCD backlight and speaker
-       - :bbl:`1 ADC` analog inputs
+       - :bbk:`5 PWM` channels for LEDs, LCD backlight and speaker
+       - :bbk:`1 ADC` analog inputs
        - 12 Programmable I/O (PIO) state machines for custom peripherals
        - 1 Watchdog timer peripheral
        - 1 Temperature sensor on-chip

--- a/boards/jsed/picoboy_color_plus/doc/helloshell_console.rsti
+++ b/boards/jsed/picoboy_color_plus/doc/helloshell_console.rsti
@@ -50,14 +50,14 @@
               DT node labels: reset
             - cdc_acm_console_uart (READY)
               DT node labels: cdc_acm_console_uart
-            - uart\ @\ 40070000 (READY)
-              DT node labels: uart0
-            - watchdog\ @\ 400d8000 (READY)
-              DT node labels: wdt0
             - timer\ @\ 400b8000 (READY)
               DT node labels: timer1
             - timer\ @\ 400b0000 (READY)
               DT node labels: timer0
+            - uart\ @\ 40070000 (READY)
+              DT node labels: uart0
+            - watchdog\ @\ 400d8000 (READY)
+              DT node labels: wdt0
             - dma\ @\ 50000000 (READY)
               DT node labels: dma
             - gpio-port\ @\ 0 (READY)
@@ -74,10 +74,16 @@
               DT node labels: pwm grove_pwm_d20 grove_pwm_d21
             - vreg\ @\ 40100000 (READY)
               DT node labels: vreg
+            - spi\ @\ 40088000 (READY)
+              DT node labels: spi1
+            - spi\ @\ 40080000 (READY)
+              DT node labels: spi0
             - lcd_backlight_en (READY)
               DT node labels: lcd_backlight_en
             - pwm_leds (READY)
               DT node labels: pwm_leds
+            - sk6805\ @\ 0 (READY)
+              DT node labels: led_strip
             - dietemp (READY)
               DT node labels: die_temp
             - stk8ba58\ @\ 18 (READY)
@@ -99,14 +105,14 @@
               DT node labels: intc
             - cdc_acm_console_uart (READY)
               DT node labels: cdc_acm_console_uart
-            - uart\ @\ 40070000 (READY)
-              DT node labels: uart0
-            - watchdog\ @\ 400d8000 (READY)
-              DT node labels: wdt0
             - timer\ @\ 400b8000 (READY)
               DT node labels: timer1
             - timer\ @\ 400b0000 (READY)
               DT node labels: timer0
+            - uart\ @\ 40070000 (READY)
+              DT node labels: uart0
+            - watchdog\ @\ 400d8000 (READY)
+              DT node labels: wdt0
             - dma\ @\ 50000000 (READY)
               DT node labels: dma
             - gpio-port\ @\ 0 (READY)
@@ -123,10 +129,16 @@
               DT node labels: pwm grove_pwm_d20 grove_pwm_d21
             - vreg\ @\ 40100000 (READY)
               DT node labels: vreg
+            - spi\ @\ 40088000 (READY)
+              DT node labels: spi1
+            - spi\ @\ 40080000 (READY)
+              DT node labels: spi0
             - lcd_backlight_en (READY)
               DT node labels: lcd_backlight_en
             - pwm_leds (READY)
               DT node labels: pwm_leds
+            - sk6805\ @\ 0 (READY)
+              DT node labels: led_strip
             - dietemp (READY)
               DT node labels: die_temp
             - stk8ba58\ @\ 18 (READY)
@@ -231,6 +243,82 @@
 
             :bgn:`uart:~$` **regulator is_enabled lcd_backlight_en**
             Regulator is disabled
+
+   .. group-tab:: LED Strip
+
+      Operate with the RGB digital LED strip :hwftlbl-led:`1 RGB`
+      at :rpi-pico-spi:`SPI1_TX`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip get_length led_strip**
+            sk6805@0 has 1 pixel(s)
+
+      Sett all LEDs to :brd:`RED`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070000 1**
+
+      Sett all LEDs to :byl:`YELLOW`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070700 1**
+
+      Sett all LEDs to :bgn:`GREEN`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000700 1**
+
+      Sett all LEDs to :bcy:`CYAN`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000707 1**
+
+      Sett all LEDs to :bbl:`BLUE`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000007 1**
+
+      Sett all LEDs to :bma:`MAGENTA`:
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070007 1**
+
+      Sett all LEDs to :bwt:`WHITE` (all on):
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 070707 1**
+
+      Sett all LEDs to :bbk:`BLACK` (all off):
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **led_strip fill led_strip 000000 1**
 
    .. group-tab:: LED
 
@@ -445,8 +533,8 @@
 
       Operate with the channels:
 
-         - on-board voltage monitor on channel :rpi-pico-adc:`ADC3`
-         - on-chip temperature sensor on channel :rpi-pico-adc:`ADC4`
+         - on-board voltage monitor on channel :rpi-pico-adc:`ADC_CH3`
+         - on-chip temperature sensor on channel :rpi-pico-adc:`ADC_CH4`
 
       .. container:: highlight highlight-console notranslate
 
@@ -549,15 +637,15 @@
    .. group-tab:: I2C
 
       The |PicoBoy Color Plus| has the on-board acceleration sensor
-      connected on I2C0. For this example the |Grove BMP280 Sensor|_
-      was also connected to I2C0 via the Qwiic / STEMMA QT connector
-      (Maker Port).
+      connected on :rpi-pico-i2c-dfl:`I2C0`. For this example the
+      |Grove BMP280 Sensor|_ was also connected to :rpi-pico-i2c-dfl:`I2C0`
+      via the Qwiic / STEMMA QT connector (Maker Port).
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c scan i2c0**
+            :bgn:`uart:~$` **i2c scan zephyr_i2c**
                  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
             00:             -- -- -- -- -- -- -- -- -- -- -- --
             10: -- -- -- -- -- -- -- -- 18 -- -- -- -- -- -- --
@@ -567,7 +655,7 @@
             50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             70: -- -- -- -- -- -- -- 77
-            2 devices found on i2c0
+            2 devices found on zephyr_i2c
 
       The I2C address ``0x18`` is a Sensortek STK8BA58_ 3D Acceleration Sensor
       and their Chip-ID can read from register ``0x0``. The Chip-ID must be
@@ -577,7 +665,7 @@
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c read_byte i2c0 18 0**
+            :bgn:`uart:~$` **i2c read_byte zephyr_i2c 18 0**
             Output: 0x87
 
       The I2C address ``0x77`` is a Bosch BMP280_ Air Pressure Sensor and their
@@ -587,7 +675,7 @@
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c read_byte i2c0 77 d0**
+            :bgn:`uart:~$` **i2c read_byte zephyr_i2c 77 d0**
             Output: 0x58
 
    .. group-tab:: Sensors
@@ -607,7 +695,7 @@
          .. parsed-literal::
 
             :bgn:`uart:~$` **sensor get dietemp**
-            channel type=12(die_temp) index=0 shift=5 num_samples=1 value=14554473307ns (31.067401)
+            channel type=12(die_temp) index=0 shift=6 num_samples=1 value=14554473307ns (31.067401)
 
       .. rubric:: on-board 3-axis accelerometer
 

--- a/boards/jsed/picoboy_color_plus/doc/pinouts.rsti
+++ b/boards/jsed/picoboy_color_plus/doc/pinouts.rsti
@@ -84,19 +84,19 @@
              .. rubric:: Sensor I/O and via Qwiic / STEMMA QT
              .. rst-class:: rst-columns edge-pinout
 
-             - | :rpi-pico-i2c-dfl:`I2C0_SDA` : :rpi-pico-uart:`UART1_TX` : GP20 (PWM4)
+             - | :rpi-pico-i2c-dfl:`I2C0_SDA` : :rpi-pico-uart:`(UART1_TX)` : GP20 (PWM4)
                | on-board maker port i/f data :rpi-pico-sys:`I2C_SDA`
                | on-board acc. sensor i/f data :rpi-pico-sys:`ACCS_SDA`
-             - | :rpi-pico-i2c-dfl:`I2C0_SCL` : :rpi-pico-uart:`UART1_RX` : GP21 (PWM5)
+             - | :rpi-pico-i2c-dfl:`I2C0_SCL` : :rpi-pico-uart:`(UART1_RX)` : GP21 (PWM5)
                | on-board maker port i/f clock :rpi-pico-sys:`I2C_SCL`
                | on-board acc. sensor i/f clock :rpi-pico-sys:`ACCS_SCL`
 
              .. rubric:: Serial I/O via solder pads
              .. rst-class:: rst-columns edge-pinout
 
-             - | :rpi-pico-uart-dfl:`UART0_TX` : :rpi-pico-i2c:`I2C1_SDA` : GP16 (PWM0)
+             - | :rpi-pico-uart-dfl:`UART0_TX` : :rpi-pico-i2c:`(I2C0_SDA)` : GP16 (PWM0)
                | on-board solder pads i/f data :rpi-pico-sys:`UART_TX`
-             - | :rpi-pico-uart-dfl:`UART0_RX` : :rpi-pico-i2c:`I2C1_SCL` : GP17 (PWM1)
+             - | :rpi-pico-uart-dfl:`UART0_RX` : :rpi-pico-i2c:`(I2C0_SCL)` : GP17 (PWM1)
                | on-board solder pads i/f data :rpi-pico-sys:`UART_RX`
 
              .. rubric:: GPIO and ADC

--- a/boards/jsed/picoboy_color_plus/picoboy_color_plus-pinctrl.dtsi
+++ b/boards/jsed/picoboy_color_plus/picoboy_color_plus-pinctrl.dtsi
@@ -57,7 +57,7 @@
 		};
 	};
 
-	i2c0_alternative: i2c0_alternative {		/* solder pads */
+	i2c0_pcbpads: i2c0_pcbpads {			/* solder pads */
 		group1617 {				/* as I2C bus */
 			pinmux = <I2C0_SDA_P16>,
 				 <I2C0_SCL_P17>;

--- a/boards/jsed/picoboy_color_plus/picoboy_color_plus.dtsi
+++ b/boards/jsed/picoboy_color_plus/picoboy_color_plus.dtsi
@@ -345,8 +345,8 @@ lcd_panel: &st7789v_240x280 {};
 		spi-zero-frame = <0xc0>;
 
 		chain-length = <1>;
-		color-mapping = <LED_COLOR_ID_RED
-				 LED_COLOR_ID_GREEN
+		color-mapping = <LED_COLOR_ID_GREEN
+				 LED_COLOR_ID_RED
 				 LED_COLOR_ID_BLUE>;
 	};
 };

--- a/boards/st/nucleo_f303re/nucleo_f303re_bbe_defconfig
+++ b/boards/st/nucleo_f303re/nucleo_f303re_bbe_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 #
 # NOTE: copy and own from original default configuration in
@@ -15,6 +15,3 @@ CONFIG_HW_STACK_PROTECTION=y
 # console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-
-# enable GPIO
-CONFIG_GPIO=y

--- a/boards/st/nucleo_f401re/nucleo_f401re_bbe_defconfig
+++ b/boards/st/nucleo_f401re/nucleo_f401re_bbe_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 #
 # NOTE: copy and own from original default configuration in
@@ -15,6 +15,3 @@ CONFIG_SERIAL=y
 # console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-
-# enable GPIO
-CONFIG_GPIO=y

--- a/boards/st/nucleo_f413zh/nucleo_f413zh_bbe_defconfig
+++ b/boards/st/nucleo_f413zh/nucleo_f413zh_bbe_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 #
 # NOTE: copy and own from original default configuration in
@@ -15,6 +15,3 @@ CONFIG_SERIAL=y
 # console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-
-# enable GPIO
-CONFIG_GPIO=y

--- a/boards/st/nucleo_f746zg/nucleo_f746zg_bbe_defconfig
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg_bbe_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 #
 # NOTE: copy and own from original default configuration in
@@ -16,6 +16,3 @@ CONFIG_SERIAL=y
 # Console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-
-# Enable GPIO
-CONFIG_GPIO=y

--- a/boards/st/nucleo_f767zi/nucleo_f767zi_bbe_defconfig
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi_bbe_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 #
 # NOTE: copy and own from original default configuration in
@@ -16,6 +16,3 @@ CONFIG_SERIAL=y
 # Console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-
-# Enable GPIO
-CONFIG_GPIO=y

--- a/boards/st/nucleo_l496zg/nucleo_l496zg_bbe_defconfig
+++ b/boards/st/nucleo_l496zg/nucleo_l496zg_bbe_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 #
 # NOTE: copy and own from original default configuration in
@@ -6,9 +6,6 @@
 
 # enable uart driver
 CONFIG_SERIAL=y
-
-# enable GPIO
-CONFIG_GPIO=y
 
 # console
 CONFIG_CONSOLE=y

--- a/boards/tiac/coffeecaller/Kconfig.defconfig
+++ b/boards/tiac/coffeecaller/Kconfig.defconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2025 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
-
-config GPIO
-	default y
-	depends on DT_HAS_NORDIC_NRF_GPIO_ENABLED
 
 # TODO: move all DELAY_* objects to Devicetree node
 config DELAY_T1H

--- a/boards/tiac/magpie_f777ni/Kconfig.defconfig
+++ b/boards/tiac/magpie_f777ni/Kconfig.defconfig
@@ -1,24 +1,24 @@
-# Copyright (c) 2021-2025 TiaC Systems
-# Copyright (c) 2021 Li-Pro.Net
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
 # TiaC Magpie F777NI board configuration
 
-if BOARD_MAGPIE_F777NI
+config CLOCK_CONTROL
+	default y
+	depends on DT_HAS_ST_STM32F4_RCC_ENABLED
 
-choice RNG_GENERATOR_CHOICE
-	default ENTROPY_DEVICE_RANDOM_GENERATOR
-	depends on ENTROPY_GENERATOR
-endchoice
+config RESET
+	default y
+	depends on DT_HAS_ST_STM32_RCC_RCTL_ENABLED
 
-if NETWORKING
+config COUNTER
+	default y
+	depends on DT_HAS_ST_STM32_RTC_ENABLED
 
 config NET_L2_ETHERNET
-	default y
-
-endif # NETWORKING
-
-endif # BOARD_MAGPIE_F777NI
+	default y if BOARD_MAGPIE_F777NI
+	depends on NETWORKING && DT_HAS_ST_STM32_ETHERNET_ENABLED
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CONSOLE := zephyr,console

--- a/boards/tiac/magpie_f777ni/doc/index.rst
+++ b/boards/tiac/magpie_f777ni/doc/index.rst
@@ -717,17 +717,27 @@ specification.
           :start-at: rtc {
           :end-at: }; // rtc
 
-       :kconfig:option:`CONFIG_CLOCK_CONTROL` and
-       :kconfig:option:`CONFIG_COUNTER` configuration:
+       :kconfig:option:`CONFIG_CLOCK_CONTROL` configuration:
 
-       .. literalinclude:: ../magpie_f777ni_defconfig
-          :caption: magpie_f777ni_defconfig
+       .. literalinclude:: ../Kconfig.defconfig
+          :caption: Kconfig.defconfig
           :language: cfg
           :encoding: ISO-8859-1
-          :emphasize-lines: 2,5
+          :emphasize-lines: 1,2
           :linenos:
-          :start-at: Clock Configuration
-          :end-before: Enable MPU
+          :start-at: config CLOCK_CONTROL
+          :end-at: depends on DT_HAS_ST_STM32F4_RCC_ENABLED
+
+       :kconfig:option:`CONFIG_COUNTER` configuration:
+
+       .. literalinclude:: ../Kconfig.defconfig
+          :caption: Kconfig.defconfig
+          :language: cfg
+          :encoding: ISO-8859-1
+          :emphasize-lines: 1,2
+          :linenos:
+          :start-at: config COUNTER
+          :end-at: depends on DT_HAS_ST_STM32_RTC_ENABLED
 
 .. _magpie_f777ni_board_gpioleds_with_dts_bindings:
 

--- a/boards/tiac/magpie_f777ni/doc/samples/net/telnet.rst
+++ b/boards/tiac/magpie_f777ni/doc/samples/net/telnet.rst
@@ -28,7 +28,9 @@ Build and flash TELNET Console as follows:
       :app: zephyr/samples/net/telnet
       :build-dir: telnet-magpie_f777ni
       :board: magpie_f777ni
-      :gen-args: -DCONFIG_NET_DHCPV4=y -DCONFIG_NET_LOG=y -DCONFIG_LOG=y -DCONFIG_GPIO_SHELL=y -DCONFIG_I2C_SHELL=y
+      :gen-args: \
+          -DCONFIG_NET_DHCPV4=y -DCONFIG_LOG=y -DCONFIG_NET_LOG=y \
+          -DCONFIG_GPIO=y -DCONFIG_GPIO_SHELL=y -DCONFIG_I2C=y -DCONFIG_I2C_SHELL=y
       :west-args: -p
       :goals: flash
       :host-os: unix

--- a/boards/tiac/magpie_f777ni/magpie_f777ni_defconfig
+++ b/boards/tiac/magpie_f777ni/magpie_f777ni_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 TiaC Systems
 # Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
 
@@ -21,10 +21,6 @@ CONFIG_SERIAL=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
-# Enable Pin-Controller
-CONFIG_PINCTRL=y
-
-# Enable GPIO, I2C, and SPI
-CONFIG_GPIO=y
+# Enable I2C and SPI
 CONFIG_I2C=y
 CONFIG_SPI=y

--- a/boards/tiac/magpie_f777ni/magpie_f777ni_defconfig
+++ b/boards/tiac/magpie_f777ni/magpie_f777ni_defconfig
@@ -1,12 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026 TiaC Systems
-# Copyright (c) 2021 Li-Pro.Net
+# SPDX-FileCopyrightText: Copyright (c) 2021 Li-Pro.Net
 # SPDX-License-Identifier: Apache-2.0
-
-# Clock Configuration
-CONFIG_CLOCK_CONTROL=y
-
-# RTC Counter
-CONFIG_COUNTER=y
 
 # Enable MPU
 CONFIG_ARM_MPU=y
@@ -20,7 +14,3 @@ CONFIG_SERIAL=y
 # Console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-
-# Enable I2C and SPI
-CONFIG_I2C=y
-CONFIG_SPI=y

--- a/boards/vccgnd/bluepill/Kconfig.defconfig
+++ b/boards/vccgnd/bluepill/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_VCCGND_BLUEPILL
@@ -26,10 +26,6 @@ config CLOCK_CONTROL
 config RESET
 	default y
 	depends on DT_HAS_ST_STM32_RCC_RCTL_ENABLED
-
-config GPIO
-	default y
-	depends on DT_HAS_ST_STM32_GPIO_ENABLED
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CONSOLE := zephyr,console

--- a/boards/waveshare/rp2350_can/doc/hardware.rsti
+++ b/boards/waveshare/rp2350_can/doc/hardware.rsti
@@ -22,7 +22,7 @@ The castellated module allows soldering direct to carrier boards.
        :hwftlbl:`4㎆`
        :hwftlbl:`520㎅`
        :hwftlbl-btn:`RST`
-       :hwftlbl-led:`GRN`
+       :hwftlbl-led:`GREEN`
        :hwftlbl-can:`L/H`
        :hwftlbl-con:`USB-C`
        :hwftlbl-con:`CAN`
@@ -37,21 +37,22 @@ The castellated module allows soldering direct to carrier boards.
 
        .. rst-class:: rst-columns
 
-       - Dual core Arm Cortex-M33 processor running up to 150㎒
+       - Dual core Arm Cortex-M33 and dual core Hazard3 (RV32IMAC+) RISC-V
+         processor running up to 150㎒
        - :bbk:`520㎅` on-chip SRAM
        - :bbk:`4㎆` on-board QSPI flash with XIP capabilities
        - USB 1.1 controller (host/device)
        - On-board :bbl:`USB-C connector`
        - On-board :bbl:`DC-DC buck-boost converter with 2.0A switch`
-       - On-board :bbl:`RESET` button
-       - On-board :bbk:`BOOT` button
-       - On-board :bbk:`LED`
+       - On-board :bbk:`RESET` button
+       - On-board :bbl:`BOOT` button
+       - On-board :bbl:`1 User LED`
        - :bbl:`26 GPIO` pins via :bbk:`edge pinout`
-       - :bbk:`2 UART` peripherals
-       - :bbk:`2 I2C` controllers
-       - :bbk:`2 SPI` controllers
-       - :bbk:`16 PWM` channels
-       - :bbl:`3 ADC` analog inputs
+       - :bbl:`2 UART` peripherals via :bbk:`edge pinout`
+       - :bbl:`2 I2C` controllers via :bbk:`edge pinout`
+       - :bbl:`2 SPI` controllers via :bbk:`edge pinout`
+       - :bbl:`16 PWM` channels via :bbk:`edge pinout`
+       - :bbl:`3 ADC` analog inputs via :bbk:`edge pinout`
        - 12 Programmable I/O (PIO) state machines for custom peripherals
        - 1 Watchdog timer peripheral
        - 1 Temperature sensor on-chip

--- a/boards/waveshare/rp2350_can/doc/helloshell.rsti
+++ b/boards/waveshare/rp2350_can/doc/helloshell.rsti
@@ -406,21 +406,38 @@ See also Bridle sample: :ref:`helloshell-sample`.
 
    .. group-tab:: ADC
 
-      Operate with the on-chip temperature sensor on ADC CH4:
+      Operate with the channels:
+
+         - on-board voltage monitor on channel :rpi-pico-adc:`ADC_CH3`
+         - on-chip temperature sensor on channel :rpi-pico-adc:`ADC_CH4`
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
             :bgn:`uart:~$` **adc adc@400a0000 resolution 12**
-            :bgn:`uart:~$` **adc adc@400a0000 channel id 4**
+            :bgn:`uart:~$` **adc adc@400a0000 print**
+            adc\ @\ 400a0000:
+            Gain: 1
+            Reference: INTERNAL
+            Acquisition Time: 0
+            Channel ID: 0
+            Differential: 0
+            Resolution: 12
+
+      .. container:: highlight highlight-console notranslate
+
+         .. parsed-literal::
+
+            :bgn:`uart:~$` **adc adc@400a0000 read 3**
+            read: 2809
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
             :bgn:`uart:~$` **adc adc@400a0000 read 4**
-            read: 891
+            read: 886
 
    .. group-tab:: Timer
 
@@ -499,13 +516,13 @@ See also Bridle sample: :ref:`helloshell-sample`.
    .. group-tab:: I2C
 
       The |RP2350-CAN| has no on-board I2C devices. For this example the
-      |Grove BMP280 Sensor|_ was connected.
+      |Grove BMP280 Sensor|_ was connected on :rpi-pico-i2c:`I2C0`.
 
       .. container:: highlight highlight-console notranslate
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c scan i2c0**
+            :bgn:`uart:~$` **i2c scan pico_i2c**
                  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
             00:             -- -- -- -- -- -- -- -- -- -- -- --
             10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -515,7 +532,7 @@ See also Bridle sample: :ref:`helloshell-sample`.
             50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
             70: -- -- -- -- -- -- -- 77
-            1 devices found on i2c0
+            1 devices found on pico_i2c
 
       The I2C address ``0x77`` is a Bosch BMP280 Air Pressure Sensor and their
       Chip-ID can read from register ``0xd0``. The Chip-ID must be ``0x58``:
@@ -524,7 +541,7 @@ See also Bridle sample: :ref:`helloshell-sample`.
 
          .. parsed-literal::
 
-            :bgn:`uart:~$` **i2c read_byte i2c0 77 d0**
+            :bgn:`uart:~$` **i2c read_byte pico_i2c 77 d0**
             Output: 0x58
 
    .. group-tab:: Sensors
@@ -543,11 +560,12 @@ See also Bridle sample: :ref:`helloshell-sample`.
          .. parsed-literal::
 
             :bgn:`uart:~$` **sensor get dietemp**
-            channel type=12(die_temp) index=0 shift=5 num_samples=1 value=40109105735ns (21.189423)
+            channel type=12(die_temp) index=0 shift=6 num_samples=1 value=40109105735ns (21.189423)
 
    .. group-tab:: CAN
 
-      Operate with the on-board CAN controller against another CAN node:
+      Operate with the on-board CAN controller
+      :brd:`against another CAN node` (not in loopback mode):
 
       .. container:: highlight highlight-console notranslate
 

--- a/boards/waveshare/rp2350_can/doc/pinouts.rsti
+++ b/boards/waveshare/rp2350_can/doc/pinouts.rsti
@@ -2,7 +2,7 @@ External pin mapping on the |RP2350-CAN| is identical to the original
 |zephyr:board:rpi_pico| board, but note that internal RP2350A GPIO lines
 23 and 24 are routed to the voltage regulator and USB connector for SMPS
 (MP28164) power saving modes and USB VBUS sense. GPIO line 25 is routed
-to the on-board user LED and GPIO line 29 will be used for VSYS/3 voltage
+to the on-board user LED and GPIO line 29 will be used for VSYS/2 voltage
 monitoring per default.
 
 In addition, GPIO lines 8 to 12 are used for control and SPI communication
@@ -19,14 +19,14 @@ in parallel.
 
    * - :on-edge(1-40):
           :hwftlbl-pio:`8`
-          :hwftlbl-pwm:`8`
+          :hwftlbl-pwm:`7`
           :hwftlbl-adc:`3`
           :hwftlbl-i2c:`2`
-          :hwftlbl-spi:`1`
+          :hwftlbl-spi:`2`
           :hwftlbl-uart:`1`
 
        :on-board:
-          :hwftlbl-led:`1 GRN`
+          :hwftlbl-led:`1 GREEN`
           :hwftlbl-can:`1 L/H`
 
        .. rubric:: Default Zephyr Peripheral Mapping
@@ -46,16 +46,16 @@ in parallel.
        - | :rpi-pico-pin:`9` PIO/PWM : :rpi-pico-pio:`GP6` :rpi-pico-pwm:`PWM6`
        - | :rpi-pico-pin:`10` PIO/PWM : :rpi-pico-pio:`GP7` :rpi-pico-pwm:`PWM7`
        - | :rpi-pico-pin:`11` :rpi-pico-pio:`GPIO8` : GP8 (PWM8)
-         | :rpi-pico-pin-nc:`nc` on-board LCD data/cmd :rpi-pico-sys:`CAN_INT`
+         | :rpi-pico-pin-nc:`nc` on-board CAN i/f interrupt :rpi-pico-sys:`CAN_INT`
        - | :rpi-pico-pin:`12` :rpi-pico-spi:`SPI1_CSN` : GP9 (PWM9)
-         | :rpi-pico-pin-nc:`nc` on-board LCD chip select :rpi-pico-sys:`CAN_CS`
+         | :rpi-pico-pin-nc:`nc` on-board CAN chip select :rpi-pico-sys:`CAN_CS`
        - | :rpi-pico-pin:`13` :rpi-pico-gnd:`GND`
        - | :rpi-pico-pin:`14` :rpi-pico-spi:`SPI1_SCK` : GP10 (PWM10)
-         | :rpi-pico-pin-nc:`nc` on-board LCD i/f clock :rpi-pico-sys:`CAN_SCLK`
+         | :rpi-pico-pin-nc:`nc` on-board CAN i/f clock :rpi-pico-sys:`CAN_SCLK`
        - | :rpi-pico-pin:`15` :rpi-pico-spi:`SPI1_TX` : GP11 (PWM11)
-         | :rpi-pico-pin-nc:`nc` on-board LCD i/f data :rpi-pico-sys:`CAN_MOSI`
+         | :rpi-pico-pin-nc:`nc` on-board CAN i/f data :rpi-pico-sys:`CAN_MOSI`
        - | :rpi-pico-pin:`16` :rpi-pico-spi:`SPI1_RX` : GP12 (PWM12)
-         | :rpi-pico-pin-nc:`nc` on-board LCD reset :rpi-pico-sys:`CAN_MISO`
+         | :rpi-pico-pin-nc:`nc` on-board CAN i/f data :rpi-pico-sys:`CAN_MISO`
        - | :rpi-pico-pin:`17` PIO/PWM : :rpi-pico-pio:`GP13` :rpi-pico-pwm:`PWM13`
        - | :rpi-pico-pin:`18` :rpi-pico-gnd:`GND`
        - | :rpi-pico-pin:`19` :rpi-pico-i2c:`I2C1_SDA` : GP14 (PWM14)
@@ -74,14 +74,14 @@ in parallel.
          | :rpi-pico-pin-nc:`nc` on-board SMPS power save :rpi-pico-sys:`PS`
        - | :rpi-pico-pin-nc:`nc` PIO/PWM : :rpi-pico-pio:`GP24` (PWM8)
          | :rpi-pico-pin-nc:`nc` on-board :rpi-pico-vdd:`VBUS/1.51` sense
-       - | :rpi-pico-pin-nc:`nc` PIO/PWM : :rpi-pico-pio:`GP25` :rpi-pico-pwm:`PWM9`
+       - | :rpi-pico-pin-nc:`nc` :hwftlbl-led:`GREEN` : :rpi-pico-pio:`GP25` :rpi-pico-pwm:`PWM9`
          | :rpi-pico-pin-nc:`nc` on-board user :rpi-pico-sys:`LED`
        - | :rpi-pico-pin:`31` :rpi-pico-adc:`ADC_CH0` : GP26 (PWM10)
        - | :rpi-pico-pin:`32` :rpi-pico-adc:`ADC_CH1` : GP27 (PWM11)
        - | :rpi-pico-pin:`33` :rpi-pico-gnd:`GND`
        - | :rpi-pico-pin:`34` :rpi-pico-adc:`ADC_CH2` : GP28 (PWM12)
        - | :rpi-pico-pin-nc:`nc` :rpi-pico-adc:`ADC_CH3` : GP29 (PWM13)
-         | :rpi-pico-pin-nc:`nc` on-board :rpi-pico-vdd:`VSYS/3` monitoring
+         | :rpi-pico-pin-nc:`nc` on-board :rpi-pico-vdd:`VSYS/2` monitoring
        - | :rpi-pico-pin:`35` :rpi-pico-adc:`ADC_VREF`
        - | :rpi-pico-pin:`36` :rpi-pico-vdd:`3V3(OUT)`
        - | :rpi-pico-pin:`37` :rpi-pico-sys:`3V3_EN`

--- a/boards/waveshare/rp2350_can/waveshare_rp2350_can_rp2350a_hazard3.yaml
+++ b/boards/waveshare/rp2350_can/waveshare_rp2350_can_rp2350a_hazard3.yaml
@@ -3,6 +3,7 @@
 
 identifier: waveshare_rp2350_can/rp2350a/hazard3
 name: Waveshare RP2350-CAN (Hazard3)
+vendor: waveshare
 type: mcu
 arch: riscv
 flash: 1024

--- a/boards/waveshare/rp2350_can/waveshare_rp2350_can_rp2350a_m33.yaml
+++ b/boards/waveshare/rp2350_can/waveshare_rp2350_can_rp2350a_m33.yaml
@@ -3,6 +3,7 @@
 
 identifier: waveshare_rp2350_can/rp2350a/m33
 name: Waveshare RP2350-CAN (Cortex-M33)
+vendor: waveshare
 type: mcu
 arch: arm
 flash: 1024

--- a/boards/weact/bluepillplus/Kconfig.defconfig
+++ b/boards/weact/bluepillplus/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_WEACT_BLUEPILLPLUS
@@ -22,10 +22,6 @@ config CLOCK_CONTROL
 config RESET
 	default y
 	depends on DT_HAS_ST_STM32_RCC_RCTL_ENABLED || DT_HAS_WCH_RCC_ENABLED
-
-config GPIO
-	default y
-	depends on DT_HAS_ST_STM32_GPIO_ENABLED || DT_HAS_WCH_GPIO_ENABLED
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CONSOLE := zephyr,console

--- a/doc/_static/css/colors.css
+++ b/doc/_static/css/colors.css
@@ -23,6 +23,10 @@
   color: var(--docset-color-theme-yellow);
 }
 
+.magenta {
+  color: var(--docset-color-theme-magenta);
+}
+
 .black {
   color: var(--docset-color-theme-black);
 }

--- a/doc/_static/css/common.css
+++ b/doc/_static/css/common.css
@@ -16,6 +16,7 @@
   --docset-color-theme-blue: #4169e1;   /* RoyalBlue */
   --docset-color-theme-cyan: #48d1cc;   /* MediumTurquoise */
   --docset-color-theme-yellow: #ffd700; /* Gold */
+  --docset-color-theme-magenta: #c71585;/* MediumVioletRed */
   --docset-color-theme-black: #000000;  /* Black */
   --docset-color-theme-gray: #cccccc;   /* Gray */
   --docset-color-theme-light: #fffaf0;  /* FloralWhite */

--- a/doc/bridle/doc_styleguide.rst
+++ b/doc/bridle/doc_styleguide.rst
@@ -144,32 +144,41 @@ The following table shows just a few examples.
      - rendered result
      - description
 
-   * - :rst:`:rd:\`normal red\``
-     - :rd:`normal red`
+   * - | :rst:`:rd:\`normal red\``
+       | :rst:`:cy:\`normal cyan\``
+     - | :rd:`normal red`
+       | :cy:`normal cyan`
      - inline colorization in normal weight
 
    * - :rst:`:i:\`italic\``
      - :i:`italic`
      - inline italic style
 
-   * - :rst:`:ign:\`italic green\``
-     - :ign:`italic green`
+   * - | :rst:`:ign:\`italic green\``
+       | :rst:`:iyl:\`italic yellow\``
+     - | :ign:`italic green`
+       | :iyl:`italic yellow`
      - inline colorization in italic style
 
    * - :rst:`:b:\`bold\``
      - :b:`bold`
      - inline bold weight
 
-   * - :rst:`:bbl:\`bold blue\``
-     - :bbl:`bold blue`
+   * - | :rst:`:bbl:\`bold blue\``
+       | :rst:`:bma:\`bold magenta\``
+     - | :bbl:`bold blue`
+       | :bma:`bold magenta`
      - inline colorization in bold weight
 
    * - :rst:`:s:\`strikethrough\``
      - :s:`strikethrough`
      - inline strikethrough decoration
 
-   * - :rst:`:syl:\`strikethrough yellow\``
-     - :syl:`strikethrough yellow`
+   * - :rst:`:swt:\`strikethrough white\``
+     - .. rst-class:: lightgray-box
+
+          :swt:`strikethrough white`
+
      - inline colorization in strikethrough decoration
 
    * - :rst:`:u:\`underline\``

--- a/doc/bridle/roles.txt
+++ b/doc/bridle/roles.txt
@@ -12,10 +12,12 @@
    :class: green
 .. role:: bl
    :class: blue
-.. role:: yl
-   :class: yellow
 .. role:: cy
    :class: cyan
+.. role:: yl
+   :class: yellow
+.. role:: ma
+   :class: magenta
 .. role:: bk
    :class: black
 .. role:: wt
@@ -35,6 +37,8 @@
    :class: italic cyan
 .. role:: iyl
    :class: italic yellow
+.. role:: ima
+   :class: italic magenta
 .. role:: ibk
    :class: italic black
 .. role:: iwt
@@ -54,6 +58,8 @@
    :class: bold cyan
 .. role:: byl
    :class: bold yellow
+.. role:: bma
+   :class: bold magenta
 .. role:: bbk
    :class: bold black
 .. role:: bwt
@@ -73,6 +79,8 @@
    :class: strikethrough cyan
 .. role:: syl
    :class: strikethrough yellow
+.. role:: sma
+   :class: strikethrough magenta
 .. role:: sbk
    :class: strikethrough black
 .. role:: swt
@@ -92,6 +100,8 @@
    :class: underline cyan
 .. role:: uyl
    :class: underline yellow
+.. role:: uma
+   :class: underline magenta
 .. role:: ubk
    :class: underline black
 .. role:: uwt

--- a/samples/helloshell/boards/cytron_maker_nano_rp2040.conf
+++ b/samples/helloshell/boards/cytron_maker_nano_rp2040.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# enable specific components
+# zephyr-keep-sorted-start
+CONFIG_LED_STRIP=y
+CONFIG_LED_STRIP_SHELL=y
+CONFIG_LED_STRIP_SHELL_MAX_PIXELS=2
+# zephyr-keep-sorted-stop

--- a/samples/helloshell/boards/cytron_maker_pi_rp2040.conf
+++ b/samples/helloshell/boards/cytron_maker_pi_rp2040.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# enable specific components
+# zephyr-keep-sorted-start
+CONFIG_LED_STRIP=y
+CONFIG_LED_STRIP_SHELL=y
+CONFIG_LED_STRIP_SHELL_MAX_PIXELS=2
+# zephyr-keep-sorted-stop

--- a/samples/helloshell/boards/cytron_motion_2350_pro_rp2350a_hazard3.conf
+++ b/samples/helloshell/boards/cytron_motion_2350_pro_rp2350a_hazard3.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# enable specific components
+# zephyr-keep-sorted-start
+CONFIG_LED_STRIP=y
+CONFIG_LED_STRIP_SHELL=y
+CONFIG_LED_STRIP_SHELL_MAX_PIXELS=2
+# zephyr-keep-sorted-stop

--- a/samples/helloshell/boards/cytron_motion_2350_pro_rp2350a_m33.conf
+++ b/samples/helloshell/boards/cytron_motion_2350_pro_rp2350a_m33.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# enable specific components
+# zephyr-keep-sorted-start
+CONFIG_LED_STRIP=y
+CONFIG_LED_STRIP_SHELL=y
+CONFIG_LED_STRIP_SHELL_MAX_PIXELS=2
+# zephyr-keep-sorted-stop

--- a/samples/helloshell/boards/picoboy_color_plus_rp2350a_hazard3.conf
+++ b/samples/helloshell/boards/picoboy_color_plus_rp2350a_hazard3.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# enable specific components
+# zephyr-keep-sorted-start
+CONFIG_LED_STRIP=y
+CONFIG_LED_STRIP_SHELL=y
+CONFIG_LED_STRIP_SHELL_MAX_PIXELS=1
+# zephyr-keep-sorted-stop

--- a/samples/helloshell/boards/picoboy_color_plus_rp2350a_m33.conf
+++ b/samples/helloshell/boards/picoboy_color_plus_rp2350a_m33.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# enable specific components
+# zephyr-keep-sorted-start
+CONFIG_LED_STRIP=y
+CONFIG_LED_STRIP_SHELL=y
+CONFIG_LED_STRIP_SHELL_MAX_PIXELS=1
+# zephyr-keep-sorted-stop

--- a/samples/helloshell/boards/waveshare_rp2040_matrix.conf
+++ b/samples/helloshell/boards/waveshare_rp2040_matrix.conf
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# enable specific components
+# zephyr-keep-sorted-start
+CONFIG_LED_STRIP=y
+CONFIG_LED_STRIP_SHELL=y
+CONFIG_LED_STRIP_SHELL_MAX_PIXELS=25
+# zephyr-keep-sorted-stop

--- a/samples/ubx_gnss/prj.conf
+++ b/samples/ubx_gnss/prj.conf
@@ -1,6 +1,7 @@
-# Copyright (c) 2022 Peter Lerup
-# Copyright (c) 2023 Rob Meades
-# Copyright (c) 2023 Sarah Renkhoff
+# SPDX-FileCopyrightText: Copyright (c) 2022 Peter Lerup
+# SPDX-FileCopyrightText: Copyright (c) 2023 Rob Meades
+# SPDX-FileCopyrightText: Copyright (c) 2023 Sarah Renkhoff
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 # Multi-threaded, with timer support in the kernel
@@ -22,6 +23,7 @@ CONFIG_SHELL=y
 CONFIG_LOG=y
 
 # Ubxlib
+CONFIG_GPIO=y
 CONFIG_SERIAL=y
 CONFIG_UBXLIB=y
 CONFIG_UBXLIB_GNSS=y


### PR DESCRIPTION
With upcoming Zephyr v4.5 some STMicro boards now has disabled `CONFIG_GPIO=y` by default on board levels. That was leading to a broken workflow in Bridle. As an fixup, Bridle now also follows this best practice. Bridle removes also `CONFIG_GPIO=y` by default on board levels and also some scattered `CONFIG_I2C=y` and `CONFIG_SPI=y`. This was the main focus on this repairing PR.

As an add-on, the PR will also provide some more minor changes on the new separated boards with improvements and refinements on DTS, documentation and samples. Thus the PR is also related to:
- #477
- #478
- #479
- #481