### PR TITLE
hotfix: doc: zephyr: ignore specific reqmgmt-catalog warning

### DIFF
--- a/doc/zephyr/known-warnings-inventory.txt
+++ b/doc/zephyr/known-warnings-inventory.txt
@@ -5,6 +5,13 @@
 .*undefined label:.*
 
 #
+# TODO: integrate the new requirement catalog from the new Zephyr module
+#       from https://github.com/zephyrproject-rtos/reqmgmt
+#
+# caused in: zephyr/doc/safety/safety_requirements/requirements_catalog.rst:13
+.*toctree contains reference to nonexisting document 'build/requirements/index'.*
+
+#
 # TODO: is ":zephyr:board-catalog:`boards using this compatible
 #       <#compatibles=ti,hdc2080>`" realy working?
 #

--- a/doc/zephyr/known-warnings.txt
+++ b/doc/zephyr/known-warnings.txt
@@ -1,2 +1,9 @@
 # Each line should contain the regular expression of a known Sphinx warning
 # that should be filtered out
+
+#
+# TODO: integrate the new requirement catalog from the new Zephyr module
+#       from https://github.com/zephyrproject-rtos/reqmgmt
+#
+# caused in: zephyr/doc/safety/safety_requirements/requirements_catalog.rst:13
+.*toctree contains reference to nonexisting document 'build/requirements/index'.*


### PR DESCRIPTION
When the Zephyr inventory and HTML pages are being generated, certain internal references to the newly introduced Zephyr requirements catalog may not yet be present. However, since warnings are intended to lead to errors, the specific references that are currently missing will be filtered out for now.

A decision must be made as soon as possible regarding Bridel as to whether the upstream change from PR zephyrproject-rtos/zephyr#115009 should be implemented, and if so, how. The following two commits require special attention:

- zephyrproject-rtos/zephyr@0080a71
- zephyrproject-rtos/zephyr@020f619

The new requirements catalog can be integrated as part of the Zephyr documentation, even though the associated data comes from a standalone Zephyr module repository (https://github.com/zephyrproject-rtos/reqmgmt). But the requirements catalog could also be integrated as a completely standalone `docset`, assuming that this does not result in any circular dependencies in the internal references.