### PR TITLE
samples: alt-config: display: rename test to avoid twister error

### DIFF
--- a/zephyr/alt-config/samples/drivers/display/tests.yaml
+++ b/zephyr/alt-config/samples/drivers/display/tests.yaml
@@ -226,7 +226,7 @@ tests:
   #
   # shield: Waveshare Pico RGB LED (matrix as display)
   #
-  sample.drivers.led_strip.waveshare_pico_rgb_led:
+  sample.drivers.display.waveshare_pico_rgb_led:
     extra_args:
       SHIELD=waveshare_pico_rgb_led
     integration_platforms:


### PR DESCRIPTION
With the introduction of support for Waveshare Pico RGB LED shields, a copy'n'past error occurred that caused the test names to mismatch and resulted in a Twister runtime error due to a duplicate test suite.

This error has now been fixed.