### PR TITLE
Fix QA integration test because of deprecated options and ROM overflow

### DIFF
--- a/boards/vccgnd/bluepill/doc/index.rst
+++ b/boards/vccgnd/bluepill/doc/index.rst
@@ -486,10 +486,10 @@ LED Blinky with USB-CDC/ACM Console
 
                   .. parsed-literal::
 
-                     [174/174] Linking C executable zephyr/zephyr.elf
+                     [187/187] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       45004 B       128 KB     34.34%
-                                  RAM:       14648 B        20 KB     71.52%
+                                FLASH:       44760 B       128 KB     34.15%
+                                  RAM:       14760 B        20 KB     72.07%
                                 SRAM0:          0 GB        20 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -512,10 +512,10 @@ LED Blinky with USB-CDC/ACM Console
 
                   .. parsed-literal::
 
-                     [174/174] Linking C executable zephyr/zephyr.elf
+                     [187/187] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       45004 B        64 KB     68.67%
-                                  RAM:       14648 B        20 KB     71.52%
+                                FLASH:       44760 B        64 KB     68.30%
+                                  RAM:       14760 B        20 KB     72.07%
                                 SRAM0:          0 GB        20 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -542,10 +542,10 @@ LED Blinky with USB-CDC/ACM Console
 
                   .. parsed-literal::
 
-                     [175/175] Linking C executable zephyr/zephyr.elf
+                     [188/188] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       44224 B       128 KB     33.74%
-                                  RAM:       14856 B        16 KB     90.67%
+                                FLASH:       44340 B       128 KB     33.83%
+                                  RAM:       14968 B        16 KB     91.36%
                                 SRAM0:          0 GB        16 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -568,10 +568,10 @@ LED Blinky with USB-CDC/ACM Console
 
                   .. parsed-literal::
 
-                     [175/175] Linking C executable zephyr/zephyr.elf
+                     [188/188] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       44224 B        64 KB     67.48%
-                                  RAM:       14856 B        16 KB     90.67%
+                                FLASH:       44340 B        64 KB     67.66%
+                                  RAM:       14968 B        16 KB     91.36%
                                 SRAM0:          0 GB        16 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -591,7 +591,7 @@ Hello Shell
                :build-dir: vccgnd_bluepill
                :board: vccgnd_bluepill_stm32f103cb
                :gen-args: \
-                  -DEXTRA_CONF_FILE="prj-hwstartup.conf" -DCONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y
+                  -DEXTRA_CONF_FILE="prj-hwstartup.conf" -DCONFIG_EXTRA_EXCEPTION_INFO=y -DCONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y
                :west-args: -p
                :flash-args: -r pyocd
                :goals: flash
@@ -604,10 +604,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [185/185] Linking C executable zephyr/zephyr.elf
+                     [194/194] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       57260 B       128 KB     43.69%
-                                  RAM:       16840 B        20 KB     82.23%
+                                FLASH:       65548 B       128 KB     50.01%
+                                  RAM:       16352 B        20 KB     79.84%
                                 SRAM0:          0 GB        20 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -631,10 +631,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [185/185] Linking C executable zephyr/zephyr.elf
+                     [193/193] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       57260 B        64 KB     87.37%
-                                  RAM:       16840 B        20 KB     82.23%
+                                FLASH:       56752 B        64 KB     86.60%
+                                  RAM:       16352 B        20 KB     79.84%
                                 SRAM0:          0 GB        20 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -663,10 +663,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [168/168] Linking C executable zephyr/zephyr.elf
+                     [177/177] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       35556 B       128 KB     27.13%
-                                  RAM:        7576 B        16 KB     46.24%
+                                FLASH:       35860 B       128 KB     27.36%
+                                  RAM:        7632 B        16 KB     46.58%
                                 SRAM0:          0 GB        16 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -691,10 +691,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [168/168] Linking C executable zephyr/zephyr.elf
+                     [177/177] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       35556 B        64 KB     54.25%
-                                  RAM:        7576 B        16 KB     46.24%
+                                FLASH:       35860 B        64 KB     54.72%
+                                  RAM:        7632 B        16 KB     46.58%
                                 SRAM0:          0 GB        16 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -719,10 +719,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [168/168] Linking C executable zephyr/zephyr.elf
+                     [177/177] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       32172 B        64 KB     49.09%
-                                  RAM:        4784 B         8 KB     58.40%
+                                FLASH:       32624 B        64 KB     49.78%
+                                  RAM:        4832 B         8 KB     58.98%
                                 SRAM0:          0 GB         8 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -747,10 +747,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [168/168] Linking C executable zephyr/zephyr.elf
+                     [177/177] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       31956 B        64 KB     48.76%
-                                  RAM:        4776 B         8 KB     58.30%
+                                FLASH:       32480 B        64 KB     49.56%
+                                  RAM:        4832 B         8 KB     58.98%
                                 SRAM0:          0 GB         8 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 

--- a/boards/weact/bluepillplus/doc/index.rst
+++ b/boards/weact/bluepillplus/doc/index.rst
@@ -496,10 +496,10 @@ LED Blinky with USB-CDC/ACM Console
 
                   .. parsed-literal::
 
-                     [174/174] Linking C executable zephyr/zephyr.elf
+                     [187/187] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       45000 B       128 KB     34.33%
-                                  RAM:       14648 B        20 KB     71.52%
+                                FLASH:       44756 B       128 KB     34.15%
+                                  RAM:       14760 B        20 KB     72.07%
                                 SRAM0:          0 GB        20 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -522,10 +522,10 @@ LED Blinky with USB-CDC/ACM Console
 
                   .. parsed-literal::
 
-                     [174/174] Linking C executable zephyr/zephyr.elf
+                     [187/187] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       45000 B        64 KB     68.66%
-                                  RAM:       14648 B        20 KB     71.52%
+                                FLASH:       44756 B        64 KB     68.29%
+                                  RAM:       14760 B        20 KB     72.07%
                                 SRAM0:          0 GB        20 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -555,10 +555,10 @@ LED Blinky with USB-CDC/ACM Console
 
                   .. parsed-literal::
 
-                     [126/126] Linking C executable zephyr/zephyr.elf
+                     [136/136] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                  ROM:       12960 B        64 KB     19.78%
-                                  RAM:        4224 B        20 KB     20.62%
+                                  ROM:       13952 B        64 KB     21.29%
+                                  RAM:        4288 B        20 KB     20.94%
                              IDT_LIST:          0 GB         4 KB      0.00%
 
          .. group-tab:: |CH32V203C6|
@@ -581,10 +581,10 @@ LED Blinky with USB-CDC/ACM Console
 
                   .. parsed-literal::
 
-                     [126/126] Linking C executable zephyr/zephyr.elf
+                     [136/136] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                  ROM:       12964 B        32 KB     39.56%
-                                  RAM:        4224 B        10 KB     41.25%
+                                  ROM:       13956 B        32 KB     42.59%
+                                  RAM:        4288 B        10 KB     41.88%
                              IDT_LIST:          0 GB         4 KB      0.00%
 
 Hello Shell
@@ -603,7 +603,7 @@ Hello Shell
                :build-dir: weact_bluepillplus
                :board: weact_bluepillplus_stm32f103cb
                :gen-args: \
-                  -DEXTRA_CONF_FILE="prj-hwstartup.conf" -DCONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y
+                  -DEXTRA_CONF_FILE="prj-hwstartup.conf" -DCONFIG_EXTRA_EXCEPTION_INFO=y -DCONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y
                :west-args: -p
                :flash-args: -r openocd
                :goals: flash
@@ -616,10 +616,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [185/185] Linking C executable zephyr/zephyr.elf
+                     [194/194] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       57264 B       128 KB     43.69%
-                                  RAM:       16840 B        20 KB     82.23%
+                                FLASH:       65552 B       128 KB     50.01%
+                                  RAM:       16352 B        20 KB     79.84%
                                 SRAM0:          0 GB        20 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -643,10 +643,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [185/185] Linking C executable zephyr/zephyr.elf
+                     [193/193] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                FLASH:       57264 B        64 KB     87.38%
-                                  RAM:       16840 B        20 KB     82.23%
+                                FLASH:       56752 B        64 KB     86.60%
+                                  RAM:       16352 B        20 KB     79.84%
                                 SRAM0:          0 GB        20 KB      0.00%
                              IDT_LIST:          0 GB        32 KB      0.00%
 
@@ -676,10 +676,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [152/152] Linking C executable zephyr/zephyr.elf
+                     [161/161] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                  ROM:       47528 B        64 KB     72.52%
-                                  RAM:        8064 B        20 KB     39.38%
+                                  ROM:       47824 B        64 KB     72.97%
+                                  RAM:        7600 B        20 KB     37.11%
                              IDT_LIST:          0 GB         4 KB      0.00%
 
          .. group-tab:: |CH32V203C6|
@@ -703,10 +703,10 @@ Hello Shell
 
                   .. parsed-literal::
 
-                     [135/135] Linking C executable zephyr/zephyr.elf
+                     [145/145] Linking C executable zephyr/zephyr.elf
                      Memory region         Used Size  Region Size  %age Used
-                                  ROM:       22596 B        32 KB     68.96%
-                                  RAM:        7136 B        10 KB     69.69%
+                                  ROM:       23576 B        32 KB     71.95%
+                                  RAM:        7200 B        10 KB     70.31%
                              IDT_LIST:          0 GB         4 KB      0.00%
 
 References

--- a/samples/helloshell/prj-hwstartup.conf
+++ b/samples/helloshell/prj-hwstartup.conf
@@ -1,8 +1,7 @@
-# Copyright (c) 2023-2026 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
-CONFIG_EXTRA_EXCEPTION_INFO=y
 CONFIG_SCHED_SIMPLE=n
 CONFIG_WAITQ_SIMPLE=n
 # zephyr-keep-sorted-stop

--- a/samples/helloshell/tests.yaml
+++ b/samples/helloshell/tests.yaml
@@ -244,10 +244,12 @@ tests:
     extra_args:
       - CMAKE_BUILD_TYPE=ZDebug
       - EXTRA_CONF_FILE="prj-hwstartup.conf"
+      - platform:vccgnd_bluepill_stm32f103cb/stm32f103xb:"CONFIG_EXTRA_EXCEPTION_INFO=y"
       - platform:vccgnd_bluepill_stm32f103cb/stm32f103xb:"CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y"
       - platform:vccgnd_bluepill_stm32f103c8/stm32f103xb:"CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y"
       - platform:weact_bluepillplus_ch32v203c8/ch32v203:"CONFIG_FLASH=n"
       - platform:weact_bluepillplus_ch32v203c8/ch32v203:"CONFIG_FLASH_SHELL=n"
+      - platform:weact_bluepillplus_stm32f103cb/stm32f103xb:"CONFIG_EXTRA_EXCEPTION_INFO=y"
       - platform:weact_bluepillplus_stm32f103cb/stm32f103xb:"CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y"
       - platform:weact_bluepillplus_stm32f103c8/stm32f103xb:"CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP=y"
     integration_platforms:


### PR DESCRIPTION
Since the `CONFIG_EXTRA_EXCEPTION_INFO` symbols is deprecated for RISC-V architectures, Bridle should handle this option with more care. Thus the option will be enabled on demand, only when needed or for test purposes with Twister.

This also handle the just happen ROM overflow on systems with really limited resources.