### PR TITLE
boards: waveshare_rp2350_matrix: remove DTS and Kconfig workarounds

### DIFF
--- a/boards/waveshare/rp2350_matrix/Kconfig.defconfig
+++ b/boards/waveshare/rp2350_matrix/Kconfig.defconfig
@@ -38,25 +38,12 @@ config PWM
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_PWM_ENABLED
 
-
-# Unfortunately, the Kconfig environment of the upstream driver does not
-# match the template specified for sensors for configuring the trigger
-# (see zephyr/drivers/sensor/Kconfig.trigger_template). The Kconfig key
-# name QMI8658A_TRIGGER_MODE is missing for the choice.
-#
-# Therefore, the dependency and default setting cannot be extended here,
-# out-of-tree or out-of-context. Instead, the desired 1-out-of-N parameter
-# must be set explicitly and individually on command line, when the build
-# command will be invoked, e.g.:
-#
-#    west build ... -- -DCONFIG_QMI8658A_TRIGGER_OWN_THREAD=y
-#
-# not yet: choice QMI8658A_TRIGGER_MODE
-# not yet: #	default QMI8658A_TRIGGER_GLOBAL_THREAD if BOARD_WAVESHARE_RP2350_MATRIX
-# not yet: 	default QMI8658A_TRIGGER_OWN_THREAD if BOARD_WAVESHARE_RP2350_MATRIX
-# not yet: 	default QMI8658A_TRIGGER_NONE
-# not yet: 	depends on SENSOR && QMI8658A
-# not yet: endchoice
+choice QMI8658A_TRIGGER_MODE
+#	default QMI8658A_TRIGGER_GLOBAL_THREAD if BOARD_WAVESHARE_RP2350_MATRIX
+	default QMI8658A_TRIGGER_OWN_THREAD if BOARD_WAVESHARE_RP2350_MATRIX
+	default QMI8658A_TRIGGER_NONE
+	depends on SENSOR && QMI8658A
+endchoice
 
 config LED_STRIP
 	default y if BOARD_WAVESHARE_RP2350_MATRIX

--- a/boards/waveshare/rp2350_matrix/doc/3dof_accel_trigger.rsti
+++ b/boards/waveshare/rp2350_matrix/doc/3dof_accel_trigger.rsti
@@ -7,7 +7,6 @@ Invoke :program:`west build` and :program:`west flash`:
       :build-dir: waveshare_rp2350_matrix
       :board: waveshare_rp2350_matrix/rp2350a/m33
       :snippets: "usb-console"
-      :gen-args: -DCONFIG_QMI8658A_TRIGGER_OWN_THREAD=y
       :west-args: -p
       :goals: flash
       :compact:
@@ -19,7 +18,6 @@ Invoke :program:`west build` and :program:`west flash`:
       :build-dir: waveshare_rp2350_matrix
       :board: waveshare_rp2350_matrix/rp2350a/hazard3
       :snippets: "usb-console"
-      :gen-args: -DCONFIG_QMI8658A_TRIGGER_OWN_THREAD=y
       :west-args: -p
       :goals: flash
       :compact:

--- a/boards/waveshare/rp2350_matrix/doc/6dof_motion_drdy.rsti
+++ b/boards/waveshare/rp2350_matrix/doc/6dof_motion_drdy.rsti
@@ -7,7 +7,6 @@ Invoke :program:`west build` and :program:`west flash`:
       :build-dir: waveshare_rp2350_matrix
       :board: waveshare_rp2350_matrix/rp2350a/m33
       :snippets: "usb-console"
-      :gen-args: -DCONFIG_QMI8658A_TRIGGER_OWN_THREAD=y
       :west-args: -p
       :goals: flash
       :compact:
@@ -19,7 +18,6 @@ Invoke :program:`west build` and :program:`west flash`:
       :build-dir: waveshare_rp2350_matrix
       :board: waveshare_rp2350_matrix/rp2350a/hazard3
       :snippets: "usb-console"
-      :gen-args: -DCONFIG_QMI8658A_TRIGGER_OWN_THREAD=y
       :west-args: -p
       :goals: flash
       :compact:

--- a/boards/waveshare/rp2350_matrix/doc/helloshell.rsti
+++ b/boards/waveshare/rp2350_matrix/doc/helloshell.rsti
@@ -9,7 +9,6 @@ See also Bridle sample: :ref:`helloshell-sample`.
       :build-dir: waveshare_rp2350_matrix
       :board: waveshare_rp2350_matrix/rp2350a/m33
       :snippets: "usb-console"
-      :gen-args: -DCONFIG_QMI8658A_TRIGGER_OWN_THREAD=y
       :west-args: -p
       :goals: flash
       :compact:
@@ -21,7 +20,6 @@ See also Bridle sample: :ref:`helloshell-sample`.
       :build-dir: waveshare_rp2350_matrix
       :board: waveshare_rp2350_matrix/rp2350a/hazard3
       :snippets: "usb-console"
-      :gen-args: -DCONFIG_QMI8658A_TRIGGER_OWN_THREAD=y
       :west-args: -p
       :goals: flash
       :compact:

--- a/boards/waveshare/rp2350_matrix/waveshare_rp2350_matrix-pinctrl.dtsi
+++ b/boards/waveshare/rp2350_matrix/waveshare_rp2350_matrix-pinctrl.dtsi
@@ -5,14 +5,6 @@
 
 #include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2350a-pinctrl.h>
 
-#if !defined(RP2_PINCTRL_GPIO_FUNC_UART_ALT)
-#  if defined(RP2_PINCTRL_GPIO_FUNC_UART_AUX)
-#    define RP2_PINCTRL_GPIO_FUNC_UART_ALT RP2_PINCTRL_GPIO_FUNC_UART_AUX
-#  else
-#    define RP2_PINCTRL_GPIO_FUNC_UART_ALT 11
-#  endif
-#endif
-
 &pinctrl {
 	clocks_default: clocks_default {
 		/* no external clocks */

--- a/doc/bridle/includes/tests_board_rows.txt
+++ b/doc/bridle/includes/tests_board_rows.txt
@@ -100,6 +100,14 @@
 
 | RP2040 | | :ref:`rpi_pico_board-extensions` | - ``rpi_pico/rp2040/w/mcuboot/bbe`` |
 
+.. waveshare_rp2040_matrix
+
+| RP2040 | | :ref:`waveshare_rp2040_matrix` | - ``waveshare_rp2040_matrix/rp2040`` |
+
+.. waveshare_rp2040_plus
+
+| RP2040 | | :ref:`waveshare_rp2040_plus` | - ``waveshare_rp2040_plus/rp2040`` |
+
 .. xiao_rp2040_rp2040_bbe
 
 | RP2040 | | :ref:`xiao_rp2040_board-extensions` | - ``xiao_rp2040/rp2040/bbe`` |
@@ -167,6 +175,14 @@
 .. rpi_pico2_rp2350a_m33_w_mcuboot_bbe
 
 | RP2350 | | :ref:`rpi_pico2_board-extensions` | - ``rpi_pico2/rp2350a/m33/w/mcuboot/bbe`` |
+
+.. waveshare_rp2350_matrix_rp2350a_hazard3
+
+| RP2350 | | :ref:`waveshare_rp2350_matrix` | - ``waveshare_rp2350_matrix/rp2350a/hazard3`` |
+
+.. waveshare_rp2350_matrix_rp2350a_m33
+
+| RP2350 | | :ref:`waveshare_rp2350_matrix` | - ``waveshare_rp2350_matrix/rp2350a/m33`` |
 
 .. xiao_rp2350_rp2350a_hazard3_bbe
 


### PR DESCRIPTION
These workarounds are no longer required (fixed in Zephyr upstream):

- In the RP2350x Pin-Ctrl header, the typo in the CPP macro for the pin function 11 has been corrected, and it is now used correctly.
- The driver for the QMI8658A sensor now also offers a _"named Kconfig choice symbol"_ for the trigger mode, and the default selection can always be enabled accordingly in the board's own `Kconfig.default` file.