### PR TITLE
deprecate master/slave terminology with Zephyr v5.0

### DIFF
--- a/drivers/mfd/mfd_sc16is75x.c
+++ b/drivers/mfd/mfd_sc16is75x.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 TiaC Systems
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -542,7 +542,7 @@ static int mfd_sc16is75x_init(const struct device *dev)
  * @brief Construct struct initializer entries for an SPI bus configuration.
  */
 #define MFD_SC16IS75X_DEFINE_SPI_BUS(inst)                                                         \
-	.spi = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER | SPI_WORD_SET(8)),                   \
+	.spi = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_CONTROLLER | SPI_WORD_SET(8)),               \
 	.bus_init = mfd_sc16is75x_spi_init
 
 /**

--- a/drivers/mfd/mfd_sipomuxgp_spi.h
+++ b/drivers/mfd/mfd_sipomuxgp_spi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 TiaC Systems
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,8 +21,9 @@ typedef struct mfd_sipomuxgp_spi_config {
 
 #define MFD_SIPOMUXGP_spi_CFG_INIT(n, b)                                                           \
 	static const mfd_sipomuxgp_spi_config_t mfd_sipomuxgp_spi_config_##n = {                   \
-		.bus = SPI_DT_SPEC_GET(INST_DT_SIPOMUXGP(n, b),                                    \
-				       SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8)),   \
+		.bus = SPI_DT_SPEC_GET(INST_DT_SIPOMUXGP(n, b), SPI_OP_MODE_CONTROLLER |           \
+									SPI_TRANSFER_MSB |         \
+									SPI_WORD_SET(8)),          \
 	};
 
 int mfd_sipomuxgp_spi_init(const struct device *dev);

--- a/drivers/mfd/sc18is604/mfd_sc18is604.c
+++ b/drivers/mfd/sc18is604/mfd_sc18is604.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 TiaC Systems
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 TiaC Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -396,8 +396,8 @@ static int mfd_sc18is604_pm_device_pm_action(const struct device *dev, enum pm_d
 
 /* clang-format off */
 #define MFD_SC18IS604_SPI_OPTS                                                                     \
-	(SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_HOLD_ON_CS | SPI_LOCK_ON | SPI_MODE_CPOL |    \
-	 SPI_MODE_CPHA | SPI_WORD_SET(8))
+	(SPI_OP_MODE_CONTROLLER | SPI_TRANSFER_MSB | SPI_HOLD_ON_CS | SPI_LOCK_ON |                \
+	 SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_WORD_SET(8))
 
 #define MFD_SC18IS604_DEFINE(inst)                                                                 \
 	IF_ENABLED(CONFIG_MFD_SC18IS604_ASYNC,                                                     \

--- a/submanifests/ubxlib.yml
+++ b/submanifests/ubxlib.yml
@@ -1,6 +1,6 @@
 # The west submanifest file for ubxlib.
 #
-# Copyright (c) 2023 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 TiaC Systems
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -29,5 +29,5 @@ manifest:
       path: modules/lib/ubxlib
       remote: tiacsys
       repo-path: ubxlib
-      revision: 7496ea2118ad2f4cee076613b697a6914931030b
+      revision: 847e1e8ce4891abe587abd03c0e86564870b5134
       submodules: true


### PR DESCRIPTION
The SPI API has been migrated to the inclusive terminology. The former names like "master" or "slave" are deprecated and will be removed in Zephyr v5.0.

`SPI_OP_MODE_CONTROLLER` and `SPI_OP_MODE_PERIPHERAL` replace `SPI_OP_MODE_MASTER` and `SPI_OP_MODE_SLAVE` which already labeled as deprecated and produce build warnings.