### PR TITLE
ci: compliance: give the linear-history rebase a git identity

### DIFF
--- a/.github/workflows/qa-compliance.yml
+++ b/.github/workflows/qa-compliance.yml
@@ -87,9 +87,20 @@ jobs:
             exit 1
           fi
 
-          # Rebase onto origin/${BASE_REF}
+          # Rebase onto origin/${BASE_REF}.
+          #
+          # An identity is REQUIRED here: whenever the head branch is behind
+          # its base, this rebase replays commits, and git refuses to write one
+          # without a configured author -- "fatal: empty ident name (for
+          # <runner@...>) not allowed". The runner has no identity of its own,
+          # so it is set here. It never reaches a published commit: the rebase
+          # is local to this checkout and is discarded with the job.
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+
           git rebase "origin/${BASE_REF}" || \
-            (echo "::error ::Rebase failed; resolve conflicts then push"; exit 1)
+            (echo "::error ::Rebase onto 'origin/${BASE_REF}' failed -- see the git output above for the reason (conflicts are only one of them)"; exit 1)
 
           # Show some history
           git log --pretty=oneline --decorate --max-count=10


### PR DESCRIPTION
The "Ensure linear history in PR" step rebases the head branch onto its base. Whenever the head is behind the base that rebase replays commits, and git refuses to write a commit without a configured author:

  fatal: empty ident name (for <runner@runnervm...>) not allowed

The runner has no identity of its own, so the step died before check_compliance.py ever ran. The job then reported "compliance.xml file is empty or missed" and "No test results found" -- both downstream symptoms of a rebase that never happened, which sends the reader looking for a compliance violation that does not exist.

Nothing published is affected: the rebase is local to the job's checkout and is discarded with it. The identity only has to exist.

The failure message is corrected at the same time. It asserted "resolve conflicts then push", but this failure had no conflicts, and saying so cost real time. It now points at git's own output instead of naming a cause it cannot know.

Reproduce: open a PR whose head branch is behind its base by at least one commit, i.e. any PR left open while its base moves.