### PR TITLE
soc: st/stm32: remove usage of duplicate SOC_* variables

### DIFF
--- a/soc/st/stm32/CMakeLists.txt
+++ b/soc/st/stm32/CMakeLists.txt
@@ -1,17 +1,17 @@
-# Copyright (c) 2024-2025 TiaC Systems
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 TiaC Systems
 # SPDX-License-Identifier: Apache-2.0
 
 if(HWMv2)
   message(NOTICE "\n"
     "\t---------------------------------------------------------------------\n"
-    "\t--- NOTICE: Use unofficially supported SoC:\t'${SOC_NAME}'\n"
+    "\t--- NOTICE: Use unofficially supported SoC:\t'${CONFIG_SOC}'\n"
     "\t--- Relying on upstream startup and initialization code in:\n"
-    "\t---\t'zephyr/soc/st/${SOC_FAMILY}'\n"
-    "\t---\t'zephyr/soc/st/${SOC_FAMILY}/${SOC_SERIES}'\n"
+    "\t---\t'zephyr/soc/st/${CONFIG_SOC_FAMILY}'\n"
+    "\t---\t'zephyr/soc/st/${CONFIG_SOC_FAMILY}/${CONFIG_SOC_SERIES}'\n"
     "\t---------------------------------------------------------------------\n"
     )
   add_subdirectory(
-    ${ZEPHYR_BASE}/soc/st/${SOC_FAMILY} ${CMAKE_CURRENT_BINARY_DIR}/zephyr
+    ${ZEPHYR_BASE}/soc/st/${CONFIG_SOC_FAMILY} ${CMAKE_CURRENT_BINARY_DIR}/zephyr
     )
 else()
   message(FATAL_ERROR "HWMv1 SoCs are not supported and must be "


### PR DESCRIPTION
Instead uses the Kconfig values directly, which are the source of truth. These variables are duplicates of Kconfig values and they do not need to exist, therefore there were deprecated in Zephyr upstream. The replacement variables are as follows:

- `SOC_NAME` -> `CONFIG_SOC`
- `SOC_SERIES` -> `CONFIG_SOC_SERIES`
- `SOC_FAMILY` -> `CONFIG_SOC_FAMILY`