### PR TITLE
samples: Add Two Display Matrix Samples

### DIFF
--- a/doc/bridle/samples.rst
+++ b/doc/bridle/samples.rst
@@ -18,7 +18,7 @@ of a single feature or library:
    :maxdepth: 1
    :glob:
 
-   samples/*/README
+   samples/**/README
 
 For more complex examples, see :ref:`applications`.
 

--- a/samples/display/colorwheel/CMakeLists.txt
+++ b/samples/display/colorwheel/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Bridle REQUIRED HINTS $ENV{BRIDLE_BASE})
+project("RGB Matrix Colour Wheel" VERSION 0.1)
+
+assert(CONFIG_DISPLAY "Zephyr's display driver API must be enabled")
+
+target_sources(app PRIVATE
+    src/main.c
+    src/hsv.c
+    src/polar.c
+)
+
+target_include_directories(app PRIVATE
+    src
+)

--- a/samples/display/colorwheel/Kconfig
+++ b/samples/display/colorwheel/Kconfig
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+menu "RGB matrix color wheel sample settings"
+
+config COLORWHEEL_HUE_STEP
+	int "Hue rotation per frame [degrees]"
+	range 0 360
+	default 1
+	help
+	  How far the color wheel rotates around the centre of the
+	  panel between two consecutive frames. Set to 0 to render a
+	  static wheel.
+
+config COLORWHEEL_FRAME_INTERVAL
+	int "Delay between two frames [milliseconds]"
+	range 1 10000
+	default 20
+	help
+	  Time to sleep between two consecutive frames. Together with
+	  COLORWHEEL_HUE_STEP this defines the angular speed of the wheel.
+	  The default of 40 ms gives 25 frames per second.
+
+config COLORWHEEL_SAT_SCALE
+	int "Radius of full saturation [% of corner distance]"
+	range 1 100
+	default 50
+	help
+	  Radius at which the saturation ramp reaches full saturation,
+	  as a percentage of the distance from the centre to a corner.
+	  Beyond this radius the color stays fully saturated all the
+	  way into the corners.
+
+config COLORWHEEL_MAX_BRIGHTNESS
+	int "Brightness ceiling"
+	range 1 255
+	default 8
+	help
+	  The brightness every pixel is driven at. The radial ramp is
+	  carried by saturation alone, so this option sets the brightness
+	  of the whole panel directly.
+
+module = COLORWHEEL
+module-str = "colorwheel"
+source "subsys/logging/Kconfig.template.log_config"
+
+endmenu
+
+# Sources Kconfig.zephyr in the Zephyr root directory.
+menu "Zephyr Kernel"
+source "Kconfig.zephyr"
+endmenu

--- a/samples/display/colorwheel/README.rst
+++ b/samples/display/colorwheel/README.rst
@@ -1,0 +1,188 @@
+.. _colorwheel-sample:
+
+Color wheel
+###########
+
+Animate a circular HSV color space projection that spins around the centre of an
+RGB LED matrix, using the Display driver API.
+
+Overview
+********
+
+This sample paints a color wheel onto an RGB LED matrix: the hue of each pixel
+follows its polar angle around the centre, so a full rainbow wraps once around
+the middle, while saturation rises with the radius. A bright white core in the
+centre blooms into fully saturated color towards the corners, and the whole
+wheel slowly spins. It drives the panel through the
+:external+zephyr:ref:`Display driver API <display_api>` rather than the LED
+strip API of the :external+zephyr:ref:`LED subsystem <led_api>`, so the same
+binary runs on panels of different geometry, wiring order and pixel format
+without any board specific code.
+
+The panel is taken from the :dts:`chosen { zephyr,display = ...; };` node, which
+on all supported boards resolves to a :dts:`led-strip-matrix` device on top of a
+WS2812 compatible LED strip. That driver maps a rectangular frame buffer onto
+the serpentine or circulative pixel order of the physical strip.
+
+Color model
+===========
+
+A color wheel is much easier to express in `HSL and HSV`_ than in RGB: hue is
+the angle, saturation is the radius, and value sets the brightness of the whole
+panel. The sample computes every pixel in HSV and converts it to RGB in
+:bridle_file:`samples/display/colorwheel/src/hsv.c`.
+
+Each pixel is placed in a polar coordinate system centered on the panel, and the
+HSV values computed as follows:
+
+.. code-block:: none
+
+   hue(x, y)        = atan2(y - cy, x - cx) + phase
+   saturation(x, y) = 255 * dist((x, y), center) / (corner_radius * scale)
+   value(x, y)      = CONFIG_COLORWHEEL_MAX_BRIGHTNESS
+
+where ``(cx, cy)`` is the center of the panel and the radius is normalised
+against a fraction of the corner distance, in percent, set by
+``CONFIG_COLORWHEEL_SAT_SCALE``, at which the ramp reaches full saturation.
+
+Configuration options
+*********************
+
+The following sample-specific Kconfig options are used in this sample
+(located in :bridle_file:`samples/display/colorwheel/Kconfig`):
+
+.. options-from-kconfig::
+
+.. important::
+
+   Keep ``CONFIG_COLORWHEEL_MAX_BRIGHTNESS`` low. A WS2812B pixel draws up to 60
+   ㎃ at full white according to the `WS2812B datasheet`_, so an 8×8 panel alone
+   can draw more than 3.5 A, far beyond what a typical board's USB supply can
+   deliver.
+
+Requirements
+************
+
+An RGB LED matrix assigned to the ``zephyr,display`` chosen node, with a
+pixel format of either RGB_888 or ARGB_8888. Either one of the following
+development boards with an on-board matrix:
+
+* |RP2350-Matrix| (Waveshare RP2350-Matrix), an 8×8 panel
+* |RP2040-Matrix| (Waveshare RP2040-Matrix), a 5×5 panel
+
+or a Raspberry Pi Pico compatible board carrying the following shield:
+
+* |Waveshare Pico RGB LED| (Waveshare Pico-RGB-LED), a 16×10 panel
+
+The sample supports the following platforms (located
+in :bridle_file:`samples/display/colorwheel/tests.yaml`):
+
+.. table-from-tests-yaml::
+
+Building and Running
+********************
+
+.. zephyr-keep-sorted-start re(^\* \w)
+
+* On |RP2350-Matrix| board, on ARM Cortex-M33:
+
+  .. zephyr-app-commands::
+     :app: bridle/samples/display/colorwheel
+     :build-dir: colorwheel-waveshare_rp2350_matrix
+     :board: waveshare_rp2350_matrix/rp2350a/m33
+     :snippets: "usb-console"
+     :west-args: -p
+     :flash-args: -r uf2
+     :goals: flash
+     :host-os: unix
+
+* On |RP2350-Matrix| board, on Hazard3 RISC-V (RV32IMAC+):
+
+  .. zephyr-app-commands::
+     :app: bridle/samples/display/colorwheel
+     :build-dir: colorwheel-waveshare_rp2350_matrix
+     :board: waveshare_rp2350_matrix/rp2350a/hazard3
+     :snippets: "usb-console"
+     :west-args: -p
+     :flash-args: -r uf2
+     :goals: flash
+     :host-os: unix
+
+* On |Waveshare Pico RGB LED| shield, on a Raspberry Pi Pico:
+
+  .. zephyr-app-commands::
+     :app: bridle/samples/display/colorwheel
+     :build-dir: colorwheel-rpi_pico
+     :board: rpi_pico/rp2040/bbe
+     :shield: waveshare_pico_rgb_led
+     :snippets: "usb-console"
+     :west-args: -p
+     :flash-args: -r uf2
+     :goals: flash
+     :host-os: unix
+
+.. zephyr-keep-sorted-stop
+
+Sample output
+=============
+
+The following output is logged on the UART console, here for the 8×8
+panel of the |RP2350-Matrix| board:
+
+.. container:: highlight highlight-console notranslate
+
+   .. parsed-literal::
+
+      \*\*\* Booting Zephyr OS build |zephyr_version_em|\ *…* \*\*\*
+      [00:00:00.003,000] <inf> colorwheel: Color wheel on a 8x8 RGB matrix, 4 bytes per pixel, 40 ms per frame
+
+Troubleshooting
+===============
+
+The panel stays dark
+   Check that the board assigns a matrix to the ``zephyr,display`` chosen
+   node. The build fails when no such node exists, but a board that chooses
+   a different kind of display reports an unsupported pixel format at run
+   time instead.
+
+The panel flickers or the board resets
+   The LED strip is almost certainly browning out the supply. Lower
+   ``CONFIG_COLORWHEEL_MAX_BRIGHTNESS``, or feed the panel from a supply
+   that can carry the current.
+
+The centre of the wheel is not white
+   The centre should be a bright white core on any panel. If it is not, the
+   matrix is most likely cropped by a ``width`` or ``height`` smaller than
+   the physical panel, which moves the geometric centre off the true
+   middle. Check the ``width`` and ``height`` properties of the matrix node
+   against the panel.
+
+Dependencies
+************
+
+This sample uses the following Zephyr libraries:
+
+* :external+zephyr:ref:`display_api`:
+
+  * ``include/zephyr/drivers/display.h``
+
+* :external+zephyr:ref:`led_api`, by way of the LED strip matrix display
+  driver
+* :external+zephyr:ref:`kernel_api`:
+
+  * ``include/zephyr/kernel.h``
+
+Known issues and limitations
+****************************
+
+The sample redraws and rewrites the whole panel on every frame, even when
+``CONFIG_COLORWHEEL_HUE_STEP`` is ``0`` and nothing has changed. This keeps
+the code simple at the cost of some unnecessary traffic to the LED strip.
+
+References
+**********
+
+.. target-notes::
+
+.. _HSL and HSV: https://en.wikipedia.org/wiki/HSL_and_HSV
+.. _WS2812B datasheet: https://www.world-semi.com/ws2812-family/

--- a/samples/display/colorwheel/prj.conf
+++ b/samples/display/colorwheel/prj.conf
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# display API on top of an LED strip matrix
+# zephyr-keep-sorted-start
+CONFIG_DISPLAY=y
+CONFIG_LED_STRIP=y
+# zephyr-keep-sorted-stop
+
+# console output and logging
+# zephyr-keep-sorted-start
+CONFIG_BOOT_BANNER=y
+CONFIG_LOG=y
+CONFIG_PRINTK=y
+# zephyr-keep-sorted-stop

--- a/samples/display/colorwheel/src/hsv.c
+++ b/samples/display/colorwheel/src/hsv.c
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "hsv.h"
+
+/** Scale @p a by the fraction @p b / 255, rounding towards zero. */
+#define SCALE8(a, b) ((uint8_t)(((uint32_t)(a) * (uint32_t)(b)) / 255U))
+
+void hsv_to_rgb(uint16_t hue, uint8_t sat, uint8_t val, struct hsv_rgb *out)
+{
+	uint8_t sector;
+	uint8_t offset;
+	uint8_t p, q, t;
+
+	if (sat == 0U) {
+		/* No saturation means a pure shade of grey. */
+		out->r = val;
+		out->g = val;
+		out->b = val;
+		return;
+	}
+
+	hue %= 360U;
+
+	/* The six 60 degree sectors of the color wheel, plus the offset within
+	 * the sector rescaled from [0, 60) to [0, 255].
+	 */
+	sector = (uint8_t)(hue / 60U);
+	offset = (uint8_t)(((hue % 60U) * 255U) / 60U);
+
+	/* The three secondary levels of the classic HSV conversion:
+	 * p is the falling channel, q falls and t rises within the sector.
+	 */
+	p = SCALE8(val, 255U - sat);
+	q = SCALE8(val, 255U - SCALE8(sat, offset));
+	t = SCALE8(val, 255U - SCALE8(sat, 255U - offset));
+
+	switch (sector) {
+	case 0: /* red -> yellow */
+		out->r = val;
+		out->g = t;
+		out->b = p;
+		break;
+	case 1: /* yellow -> green */
+		out->r = q;
+		out->g = val;
+		out->b = p;
+		break;
+	case 2: /* green -> cyan */
+		out->r = p;
+		out->g = val;
+		out->b = t;
+		break;
+	case 3: /* cyan -> blue */
+		out->r = p;
+		out->g = q;
+		out->b = val;
+		break;
+	case 4: /* blue -> magenta */
+		out->r = t;
+		out->g = p;
+		out->b = val;
+		break;
+	default: /* magenta -> red */
+		out->r = val;
+		out->g = p;
+		out->b = q;
+		break;
+	}
+}

--- a/samples/display/colorwheel/src/hsv.h
+++ b/samples/display/colorwheel/src/hsv.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef COLORWHEEL_HSV_H_
+#define COLORWHEEL_HSV_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief A color in the sRGB cube, one byte per channel. */
+struct hsv_rgb {
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+};
+
+/**
+ * @brief Convert an HSV color into its RGB representation.
+ *
+ * The conversion is done entirely in integer arithmetic, so it is cheap
+ * enough to run per pixel and per frame even on a core without an FPU.
+ *
+ * @param hue Hue in degrees. Values outside [0, 360) are wrapped.
+ * @param sat Saturation, from 0 (grey) to 255 (fully saturated).
+ * @param val Value (brightness), from 0 (black) to 255 (full).
+ * @param out Destination color, must not be @c NULL.
+ */
+void hsv_to_rgb(uint16_t hue, uint8_t sat, uint8_t val, struct hsv_rgb *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COLORWHEEL_HSV_H_ */

--- a/samples/display/colorwheel/src/main.c
+++ b/samples/display/colorwheel/src/main.c
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/display.h>
+#include <zephyr/logging/log.h>
+
+#include "hsv.h"
+#include "polar.h"
+
+LOG_MODULE_REGISTER(colorwheel, CONFIG_COLORWHEEL_LOG_LEVEL);
+
+#if !DT_HAS_CHOSEN(zephyr_display)
+#error "This sample needs an RGB matrix assigned to the chosen zephyr,display node"
+#endif
+
+#define MATRIX_NODE   DT_CHOSEN(zephyr_display)
+#define MATRIX_WIDTH  DT_PROP(MATRIX_NODE, width)
+#define MATRIX_HEIGHT DT_PROP(MATRIX_NODE, height)
+
+/* The frame buffer is sized at build time for the worst case, ARGB_8888
+ * with four bytes per pixel. The actual pixel format is queried at run
+ * time and may be narrower.
+ */
+#define MATRIX_MAX_BPP 4U
+#define FRAME_BUF_SIZE ((size_t)MATRIX_WIDTH * MATRIX_HEIGHT * MATRIX_MAX_BPP)
+
+static uint8_t frame_buf[FRAME_BUF_SIZE];
+
+/** @brief Bytes per pixel, or 0 if the format is not supported. */
+static size_t bytes_per_pixel(enum display_pixel_format format)
+{
+	switch (format) {
+	case PIXEL_FORMAT_ARGB_8888:
+		return 4U;
+	case PIXEL_FORMAT_RGB_888:
+		return 3U;
+	default:
+		return 0U;
+	}
+}
+
+/** @brief Write one color to the frame buffer at @p dst. */
+static void put_pixel(uint8_t *dst, enum display_pixel_format format, const struct hsv_rgb *color)
+{
+	if (format == PIXEL_FORMAT_ARGB_8888) {
+		uint32_t argb = 0xFF000000U | ((uint32_t)color->r << 16) |
+				((uint32_t)color->g << 8) | (uint32_t)color->b;
+
+		/* An unaligned native store, matching how the LED strip
+		 * matrix driver reads the pixel back.
+		 */
+		memcpy(dst, &argb, sizeof(argb));
+	} else {
+		dst[0] = color->r;
+		dst[1] = color->g;
+		dst[2] = color->b;
+	}
+}
+
+/**
+ * @brief Paint one full frame of the color wheel into @p buf.
+ *
+ * Each pixel is placed in polar coordinates centred on the panel. Hue
+ * follows the polar angle, so a full rainbow wraps once around the
+ * centre, while saturation rises with the radius: a bright white core
+ * in the centre blooms into fully saturated color. The radius is
+ * normalised against a fraction of the corner distance set by
+ * CONFIG_COLORWHEEL_SAT_SCALE, so the ramp reaches full saturation
+ * before the corners. The value is fixed at
+ * CONFIG_COLORWHEEL_MAX_BRIGHTNESS, keeping the white core bright and
+ * bounding the panel's current draw.
+ *
+ * Advancing @p phase between frames rotates the wheel.
+ */
+static void render_frame(uint8_t *buf, uint16_t width, uint16_t height,
+			 enum display_pixel_format format, size_t bpp, uint16_t phase)
+{
+	/* Pixel-centred coordinates in units of 1/8 pixel, so the origin lands on the geometric
+	 * centre of the panel even when a dimension is even and no pixel sits exactly on it.
+	 */
+	const uint32_t center_w = (uint32_t)width * COLORWHEEL_COORD_ONE - 1U;
+	const uint32_t center_h = (uint32_t)height * COLORWHEEL_COORD_ONE - 1U;
+
+	/* Reference radius: the panel corner, in the same units. The saturation ramp is scaled to
+	 * reach full saturation at a fraction of this corner distance. The scale is a percentage,
+	 * so the computation stays in integer arithmetic.
+	 */
+	const int32_t corner_x = (int32_t)(center_w / 2U);
+	const int32_t corner_y = (int32_t)(center_h / 2U);
+	const uint32_t corner = polar_isqrt((uint32_t)(corner_x * corner_x + corner_y * corner_y));
+	const uint32_t radius_max = (corner * (uint32_t)CONFIG_COLORWHEEL_SAT_SCALE) / 100U;
+
+	for (uint16_t y = 0U; y < height; y++) {
+		for (uint16_t x = 0U; x < width; x++) {
+			const int32_t fx = (int32_t)((uint32_t)x * COLORWHEEL_COORD_ONE) -
+					   (int32_t)(center_w / 2U);
+			const int32_t fy = (int32_t)((uint32_t)y * COLORWHEEL_COORD_ONE) -
+					   (int32_t)(center_h / 2U);
+			const uint32_t radius = polar_isqrt((uint32_t)(fx * fx + fy * fy));
+			const uint16_t angle = polar_atan2_deg(fy, fx);
+			struct hsv_rgb color;
+			uint32_t saturation;
+
+			/* Saturation is the radius normalised to [0, 255] against the scaled
+			 * reference: a white core in the centre, fully saturated color at the
+			 * reference radius, clamped beyond it. The value stays at the brightness
+			 * ceiling, so the core stays bright and the panel draws a bounded current.
+			 */
+			saturation = (radius_max != 0U) ? ((radius * 255U) / radius_max) : 0U;
+			if (saturation > 255U) {
+				saturation = 255U;
+			}
+
+			hsv_to_rgb((uint16_t)(((uint32_t)angle + phase) % 360U),
+				   (uint8_t)saturation, (uint8_t)CONFIG_COLORWHEEL_MAX_BRIGHTNESS,
+				   &color);
+
+			put_pixel(buf, format, &color);
+			buf += bpp;
+		}
+	}
+}
+
+int main(void)
+{
+	const struct device *const display = DEVICE_DT_GET(MATRIX_NODE);
+	struct display_buffer_descriptor desc;
+	struct display_capabilities caps;
+	enum display_pixel_format format;
+	uint16_t phase = 0U;
+	size_t bpp;
+	int ret;
+
+	if (!device_is_ready(display)) {
+		LOG_ERR("Display device %s is not ready", display->name);
+		return -ENODEV;
+	}
+
+	display_get_capabilities(display, &caps);
+	format = caps.current_pixel_format;
+	bpp = bytes_per_pixel(format);
+
+	if (bpp == 0U) {
+		LOG_ERR("Pixel format %d is not supported, need RGB_888 or ARGB_8888", format);
+		return -ENOTSUP;
+	}
+
+	if ((caps.x_resolution > MATRIX_WIDTH) || (caps.y_resolution > MATRIX_HEIGHT)) {
+		LOG_ERR("Display is %ux%u, but the frame buffer only holds %ux%u",
+			caps.x_resolution, caps.y_resolution, (unsigned int)MATRIX_WIDTH,
+			(unsigned int)MATRIX_HEIGHT);
+		return -ENOMEM;
+	}
+
+	/* The LED strip matrix driver does not implement blanking,
+	 * so -ENOSYS is not an error.
+	 */
+	ret = display_blanking_off(display);
+	if ((ret < 0) && (ret != -ENOSYS)) {
+		LOG_ERR("Failed to switch off display blanking (%d)", ret);
+		return ret;
+	}
+
+	desc.width = caps.x_resolution;
+	desc.height = caps.y_resolution;
+	desc.pitch = caps.x_resolution;
+	desc.buf_size = (uint32_t)caps.x_resolution * caps.y_resolution * bpp;
+	desc.frame_incomplete = false;
+
+	LOG_INF("Color wheel on a %ux%u RGB matrix, %u bytes per pixel, %u ms per frame",
+		caps.x_resolution, caps.y_resolution, (unsigned int)bpp,
+		(unsigned int)CONFIG_COLORWHEEL_FRAME_INTERVAL);
+
+	while (true) {
+		render_frame(frame_buf, caps.x_resolution, caps.y_resolution, format, bpp, phase);
+
+		ret = display_write(display, 0, 0, &desc, frame_buf);
+		if (ret < 0) {
+			LOG_ERR("Failed to write a frame to the display (%d)", ret);
+			return ret;
+		}
+
+		phase = (uint16_t)((phase + CONFIG_COLORWHEEL_HUE_STEP) % 360U);
+
+		k_sleep(K_MSEC(CONFIG_COLORWHEEL_FRAME_INTERVAL));
+	}
+}

--- a/samples/display/colorwheel/src/polar.c
+++ b/samples/display/colorwheel/src/polar.c
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "polar.h"
+
+/*
+ * First octant arctangent, shared by both branches of polar_atan2_deg.
+ *
+ * Approximates atan(r) for a ratio @p r already scaled into [0, 1024] and
+ * returns the angle in 1/1024 of a degree, using the rational form
+ *
+ *   atan(r) ~= r * (45 + 15.65 * (1 - r))        (degrees, 0 <= r <= 1)
+ *
+ * with a worst case error of 0.21 degrees. The coefficient is carried as
+ * 15.65 * 1024 = 16026 to keep the evaluation in 32 bit integer
+ * arithmetic, cheap enough for a per pixel inner loop without an FPU. The
+ * error is far below the angular resolution of a discrete matrix, where
+ * one pixel step near the centre spans several degrees.
+ */
+#define ATAN_K0 (45 * 1024)
+#define ATAN_K1 16026
+
+static int32_t atan_first_octant(int32_t r)
+{
+	return (r * (ATAN_K0 + ATAN_K1 - ((ATAN_K1 * r) >> 10))) >> 10;
+}
+
+uint16_t polar_atan2_deg(int32_t y, int32_t x)
+{
+	const int32_t ax = (x >= 0) ? x : -x;
+	const int32_t ay = (y >= 0) ? y : -y;
+	int32_t angle;
+
+	if ((ax == 0) && (ay == 0)) {
+		return 0U;
+	}
+
+	/* Fold the vector into the first octant, evaluate the arctangent of
+	 * the slope, then re-apply the signs to unfold the reflections
+	 * into the correct quadrant.
+	 */
+	if (ax >= ay) {
+		angle = atan_first_octant((ay << 10) / ax) >> 10;
+	} else {
+		angle = 90 - (atan_first_octant((ax << 10) / ay) >> 10);
+	}
+
+	if (y < 0) {
+		angle = -angle;
+	}
+	if (x < 0) {
+		angle = 180 - angle;
+	}
+
+	return (uint16_t)(((angle % 360) + 360) % 360);
+}
+
+uint32_t polar_isqrt(uint32_t v)
+{
+	uint32_t r = 0U;
+	uint32_t bit = 1UL << 30;
+
+	while (bit > v) {
+		bit >>= 2;
+	}
+
+	while (bit != 0U) {
+		if (v >= r + bit) {
+			v -= r + bit;
+			r = (r >> 1) + bit;
+		} else {
+			r >>= 1;
+		}
+		bit >>= 2;
+	}
+
+	return r;
+}

--- a/samples/display/colorwheel/src/polar.h
+++ b/samples/display/colorwheel/src/polar.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef COLORWHEEL_POLAR_H_
+#define COLORWHEEL_POLAR_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Fixed point shift for pixel-centred coordinates, units of 1/8 pixel. */
+#define COLORWHEEL_COORD_SHIFT 3U
+/** One pixel step in the fixed point coordinates. */
+#define COLORWHEEL_COORD_ONE   (1U << COLORWHEEL_COORD_SHIFT)
+
+/**
+ * @brief Four quadrant arctangent in degrees.
+ *
+ * Computes the angle of the vector (@p y, @p x) counter-clockwise from the
+ * positive x axis, mapped into [0, 360). Integer only, cheap enough to
+ * evaluate per pixel and per frame on a core without an FPU, and accurate
+ * to within a single step of the color wheel.
+ *
+ * @param y Y coordinate of the vector, in any fixed point unit.
+ * @param x X coordinate of the vector, in the same unit as @p y.
+ * @return Angle in degrees, from 0 up to but not including 360.
+ */
+uint16_t polar_atan2_deg(int32_t y, int32_t x);
+
+/**
+ * @brief Integer square root via the bit by bit method.
+ *
+ * @param v Input value.
+ * @return The largest integer @p r with @p r * @p r <= @p v.
+ */
+uint32_t polar_isqrt(uint32_t v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COLORWHEEL_POLAR_H_ */

--- a/samples/display/colorwheel/tests.yaml
+++ b/samples/display/colorwheel/tests.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  description: Animated color wheel on an RGB LED matrix
+  name: colorwheel
+common:
+  tags:
+    - bridle
+    - drivers
+    - display
+    - led_strip
+  sysbuild: false
+  build_only: true
+  filter: dt_chosen_enabled("zephyr,display") and
+          dt_compat_enabled("led-strip-matrix")
+tests:
+  bridle.sample.colorwheel:
+    platform_allow:
+      - waveshare_rp2040_matrix
+      - waveshare_rp2350_matrix/rp2350a/hazard3
+      - waveshare_rp2350_matrix/rp2350a/m33
+    integration_platforms:
+      - waveshare_rp2040_matrix
+      - waveshare_rp2350_matrix/rp2350a/hazard3
+      - waveshare_rp2350_matrix/rp2350a/m33
+  bridle.sample.colorwheel.shield:
+    extra_args: SHIELD=waveshare_pico_rgb_led
+    platform_allow:
+      - rpi_pico/rp2040/bbe
+      - rpi_pico/rp2040/w/bbe
+      - rpi_pico2/rp2350a/hazard3/bbe
+      - rpi_pico2/rp2350a/m33/bbe
+      - rpi_pico2/rp2350a/m33/w/bbe
+      - waveshare_rp2040_lcd_0_96
+      - waveshare_rp2040_plus
+      - waveshare_rp2350_can/rp2350a/hazard3
+      - waveshare_rp2350_can/rp2350a/m33
+    integration_platforms:
+      - rpi_pico/rp2040/bbe
+      - rpi_pico2/rp2350a/hazard3/bbe
+      - rpi_pico2/rp2350a/m33/bbe
+      - waveshare_rp2040_plus

--- a/samples/display/level/CMakeLists.txt
+++ b/samples/display/level/CMakeLists.txt
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Bridle REQUIRED HINTS $ENV{BRIDLE_BASE})
+project("RGB Matrix Level" VERSION 0.1)
+
+assert(CONFIG_DISPLAY "Zephyr's display driver API must be enabled")
+assert(CONFIG_SENSOR "Zephyr's sensor driver API must be enabled")
+
+target_sources(app PRIVATE
+    src/main.c
+    src/bubble.c
+    src/matrix.c
+    src/tilt.c
+)
+
+target_include_directories(app PRIVATE
+    src
+)

--- a/samples/display/level/Kconfig
+++ b/samples/display/level/Kconfig
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+menu "RGB matrix level sample settings"
+
+config LEVEL_COLOR_RANGE_TILT
+	int "Tilt angle over which the bubble changes colour [tenths of a degree]"
+	range 1 600
+	default 10
+	help
+	  At this angle and beyond, the bubble is fully the far colour; at
+	  dead level it is fully the near colour; in between it is mixed.
+	  Should be far tighter than LEVEL_FULL_SCALE_TILT.
+
+config LEVEL_LOCK_TILT
+	int "Tilt angle below which the board counts as level [tenths of a degree]"
+	range 0 600
+	default 3
+	help
+	  Below this tilt the bubble latches fully to the near colour.
+	  Keep well inside LEVEL_COLOR_RANGE_TILT. Set to 0 to disable
+	  the latch.
+
+config LEVEL_LOCK_HYSTERESIS
+	int "Extra tilt needed to break the level latch [tenths of a degree]"
+	range 0 600
+	default 2
+	help
+	  The latch engages at LEVEL_LOCK_TILT and releases at
+	  LEVEL_LOCK_TILT plus this, so the two form a band rather than
+	  a single edge that would flicker on noise.
+
+config LEVEL_FULL_SCALE_TILT
+	int "Tilt angle at which the bubble reaches the panel edge [degrees]"
+	range 1 60
+	default 10
+	help
+	  Tilt that moves the bubble from the centre of the panel all the
+	  way to the rim; sets the sensitivity of the instrument.
+
+config LEVEL_FILTER_TIME_CONSTANT
+	int "Low pass filter time constant [milliseconds]"
+	range 0 5000
+	default 100
+	help
+	  Time constant of the first order low pass filter on the
+	  acceleration reading. Set to 0 to disable filtering. Quoted as
+	  a time rather than a per sample weight, so the smoothing is
+	  independent of LEVEL_FRAME_INTERVAL.
+
+config LEVEL_FRAME_INTERVAL
+	int "Delay between two frames [milliseconds]"
+	range 1 10000
+	default 40
+	help
+	  Also the rate at which the inertial sensor is polled.
+
+config LEVEL_SENSOR_LOG_INTERVAL
+	int "Delay between two logged sensor readings [milliseconds]"
+	range 0 60000
+	default 1000
+	help
+	  Throttles the log output only; sampling always runs at
+	  LEVEL_FRAME_INTERVAL. Set to 0 to log every sample.
+
+config LEVEL_TEST_IMAGE_MS
+	int "Show the corner test image at startup [milliseconds]"
+	range 0 10000
+	default 2000
+	help
+	  Lights the four corner pixels in red, green, blue and white to
+	  show where the origin of the display physically sits. Set to 0
+	  to skip the test image.
+
+menu "Sensor to panel axis mapping"
+
+comment "Determine these empirically, see the README"
+
+# How the sensor is mounted relative to the panel is a per board
+# property, so measured boards get their mapping as a default here and
+# every other board falls back to the identity mapping.
+
+config LEVEL_AXIS_SWAP_XY
+	bool "Swap the sensor X and Y axes"
+	default y if BOARD_WAVESHARE_RP2350_MATRIX
+	help
+	  Feed the sensor Y axis into the panel X axis and vice versa.
+	  Applied before the inversions.
+
+config LEVEL_AXIS_INVERT_X
+	bool "Invert the panel X axis"
+	default y if BOARD_WAVESHARE_RP2350_MATRIX
+	help
+	  Negate the horizontal component, after any swap.
+
+config LEVEL_AXIS_INVERT_Y
+	bool "Invert the panel Y axis"
+	help
+	  Negate the vertical component, after any swap.
+
+endmenu
+
+config LEVEL_BRIGHTNESS
+	int "Brightness of the bubble and the test image"
+	range 1 255
+	default 32
+	help
+	  The channel level a fully lit primary colour is drawn at. This
+	  is also the number of brightness steps the sub-pixel
+	  positioning has to work with.
+
+module = LEVEL
+module-str = "level"
+source "subsys/logging/Kconfig.template.log_config"
+
+endmenu
+
+# Sources Kconfig.zephyr in the Zephyr root directory.
+menu "Zephyr Kernel"
+source "Kconfig.zephyr"
+endmenu

--- a/samples/display/level/README.rst
+++ b/samples/display/level/README.rst
@@ -1,0 +1,221 @@
+.. _level-sample:
+
+Level
+#####
+
+A digital spirit level on an RGB LED matrix, driven through the Display
+driver API and fed from an accelerometer.
+
+Overview
+********
+
+This sample turns the board into a digital spirit level. The on-board
+accelerometer measures which way is down, and a bubble drawn on the RGB LED
+matrix runs towards whichever edge of the board is raised, exactly like the
+bubble in a vial. Hold the board flat and the bubble returns to the middle of
+the panel.
+
+The panel is driven through the :external+zephyr:ref:`Display driver API
+<display_api>` and the sensor through the :external+zephyr:ref:`Sensor driver
+API <sensor>`, so the same binary runs on panels of different geometry, wiring
+order and pixel format without any board specific code. The panel is taken from
+the :dts:`chosen { zephyr,display = ...; };` node, which on the supported board
+resolves to a :dts:`led-strip-matrix` device on top of a WS2812 compatible LED
+strip. The sensor is taken from the ``accel0`` alias; only the accelerometer is
+used, since a level needs the drift-free reference that gravity provides and a
+gyroscope does not.
+
+Techniques worth knowing about:
+
+* The acceleration vector is normalised against its own length, which turns the
+  in-plane components into plain sines of the tilt angle, and is smoothed by a
+  first order low pass filter before use.
+* The bubble is rendered with sub-pixel accuracy: instead of snapping to the
+  nearest pixel, its light is spread bilinearly over the up to four pixels it
+  straddles.
+* Since position runs out of resolution near the centre, the bubble also changes
+  colour over a much tighter angle than it moves over, and latches to the near
+  colour, with hysteresis, once the board is level.
+
+Requirements
+************
+
+An RGB LED matrix assigned to the ``zephyr,display`` chosen node, with a pixel
+format of either RGB_888 or ARGB_8888, **and** a 3-axis accelerometer assigned
+to the ``accel0`` alias.
+
+The sample supports the following platforms (located in
+:bridle_file:`samples/display/level/tests.yaml`):
+
+.. table-from-tests-yaml::
+
+Configuration options
+*********************
+
+The following sample-specific Kconfig options are used in this sample
+(located in :bridle_file:`samples/display/level/Kconfig`):
+
+.. options-from-kconfig::
+
+.. important::
+
+   Keep ``CONFIG_LEVEL_BRIGHTNESS`` low. A WS2812B pixel draws up to 60 ㎃ at
+   full white according to the `WS2812B datasheet`_, so an 8×8 panel alone can
+   draw more than 3.5 A, far beyond what a typical board's USB supply can
+   deliver.
+
+Building and Running
+********************
+
+.. zephyr-keep-sorted-start re(^\* \w)
+
+* On |RP2350-Matrix| board, on ARM Cortex-M33:
+
+  .. zephyr-app-commands::
+     :app: bridle/samples/display/level
+     :build-dir: level-waveshare_rp2350_matrix
+     :board: waveshare_rp2350_matrix/rp2350a/m33
+     :snippets: "usb-console"
+     :west-args: -p
+     :flash-args: -r uf2
+     :goals: flash
+     :host-os: unix
+
+* On |RP2350-Matrix| board, on Hazard3 RISC-V (RV32IMAC+):
+
+  .. zephyr-app-commands::
+     :app: bridle/samples/display/level
+     :build-dir: level-waveshare_rp2350_matrix
+     :board: waveshare_rp2350_matrix/rp2350a/hazard3
+     :snippets: "usb-console"
+     :west-args: -p
+     :flash-args: -r uf2
+     :goals: flash
+     :host-os: unix
+
+.. zephyr-keep-sorted-stop
+
+Sample output
+=============
+
+The following output is logged on the UART console, here for the 8×8
+panel of the |RP2350-Matrix| board lying nearly flat on the table:
+
+.. container:: highlight highlight-console notranslate
+
+   .. parsed-literal::
+
+      \*\*\* Booting Zephyr OS build |zephyr_version_em|\ *…* \*\*\*
+      [00:00:00.003,000] <inf> level: Level on a 8x8 RGB matrix, 4 bytes per pixel, 40 ms per frame
+      [00:00:00.003,000] <inf> level: Inertial sensor is qmi8658a\ @\ 6b, full scale tilt is 10 deg
+      [00:00:00.003,000] <inf> level: Axis map: swap-xy yes, invert-x yes, invert-y no
+      [00:00:00.003,000] <inf> level: Filter time constant is 100 ms, giving a weight of 0.330 per sample
+      [00:00:00.003,000] <inf> level: Colour ramps below 1.0 deg, latches level below 0.5 deg, releases at 0.8 deg
+      [00:00:02.010,000] <inf> level: accel  -0.569  -1.183  -9.630 m/s^2, \|a|  9.719
+      [00:00:02.010,000] <inf> level: tilt  x +0.122 y -0.059, angle  7.76 deg
+      [00:00:02.010,000] <inf> level: dot    5.95,  2.32, proximity 0.00
+
+.. _level-axis-mapping:
+
+Axis mapping
+============
+
+Nothing in the devicetree says how the sensor is oriented relative to the
+panel, and a bubble floats towards the *raised* edge, the opposite of
+where the gravity vector points. Both are folded into the
+``CONFIG_LEVEL_AXIS_*`` options, defaulted per board:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Board
+     - ``SWAP_XY``
+     - ``INVERT_X``
+     - ``INVERT_Y``
+   * - |RP2350-Matrix|
+     - yes
+     - yes
+     - no
+   * - anything else
+     - no
+     - no
+     - no
+
+To bring up a new board:
+
+#. Lay the board flat, LEDs up. Note where the corner test image puts its red
+   pixel: that is the origin of the panel.
+#. Build and flash with all three switches off. Raise the edge **closest
+   to you** and watch the bubble:
+
+   * It moves towards you: correct, leave the switches alone.
+   * It moves away from you: set ``CONFIG_LEVEL_AXIS_INVERT_Y=y``.
+   * It moves left or right instead: set ``CONFIG_LEVEL_AXIS_SWAP_XY=y``
+     and repeat this step.
+
+#. Raise the **left** edge. If the bubble moves right instead of left,
+   set ``CONFIG_LEVEL_AXIS_INVERT_X=y``.
+#. Record the result as a per board default in
+   :bridle_file:`samples/display/level/Kconfig`.
+
+The console prints the mapping in use at startup. Zephyr's
+:dts:`sensor-axis-align` devicetree convention would be the proper home
+for the hardware half of this mapping, but the ``qst,qmi8658a`` binding
+does not support it yet.
+
+Troubleshooting
+===============
+
+The panel stays dark
+   Check that the board assigns a matrix to the ``zephyr,display`` chosen
+   node. The build fails when no such node exists, but a board that chooses
+   a different kind of display reports an unsupported pixel format at run
+   time instead.
+
+The corner colours are wrong or the image is mirrored
+   The panel is not wired the way the matrix node describes. Review the
+   ``circulative``, ``serpentine`` and ``color-mapping`` properties.
+
+The dot runs the wrong way
+   The sensor is not oriented the way the panel is. Work through
+   :ref:`level-axis-mapping`.
+
+The dot never leaves the middle, or pins to the rim at the slightest tilt
+   ``CONFIG_LEVEL_FULL_SCALE_TILT`` is too large or too small for the way
+   you are holding the board. The console reports the measured angle in
+   degrees, so compare that against the configured full scale.
+
+The bubble will not sit still, or lags behind your hand
+   Adjust ``CONFIG_LEVEL_FILTER_TIME_CONSTANT``: raise it for
+   steadiness, lower it for responsiveness. Set it to ``0`` to see the
+   raw, unfiltered reading.
+
+The colour flickers while the board is nearly level
+   Raise ``CONFIG_LEVEL_LOCK_HYSTERESIS``. Set it to ``0`` once to see
+   the flicker it is there to prevent.
+
+Dependencies
+************
+
+This sample uses the following Zephyr libraries:
+
+* :external+zephyr:ref:`display_api`:
+
+  * ``include/zephyr/drivers/display.h``
+
+* :external+zephyr:ref:`sensor`:
+
+  * ``include/zephyr/drivers/sensor.h``
+
+* :external+zephyr:ref:`led_api`, by way of the LED strip matrix display
+  driver
+* :external+zephyr:ref:`kernel_api`:
+
+  * ``include/zephyr/kernel.h``
+
+References
+**********
+
+.. target-notes::
+
+.. _WS2812B datasheet: https://www.world-semi.com/ws2812-family/

--- a/samples/display/level/prj.conf
+++ b/samples/display/level/prj.conf
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+# display API on top of an LED strip matrix
+# zephyr-keep-sorted-start
+CONFIG_DISPLAY=y
+CONFIG_LED_STRIP=y
+# zephyr-keep-sorted-stop
+
+# inertial measurement unit on I2C, polled through the sensor API
+# zephyr-keep-sorted-start
+CONFIG_I2C=y
+CONFIG_SENSOR=y
+# zephyr-keep-sorted-stop
+
+# console output and logging, with floating point for the sensor readings
+# zephyr-keep-sorted-start
+CONFIG_BOOT_BANNER=y
+CONFIG_CBPRINTF_FP_SUPPORT=y
+CONFIG_LOG=y
+CONFIG_PRINTK=y
+# zephyr-keep-sorted-stop

--- a/samples/display/level/src/bubble.c
+++ b/samples/display/level/src/bubble.c
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <math.h>
+
+#include <zephyr/logging/log.h>
+
+#include "bubble.h"
+
+LOG_MODULE_DECLARE(level, CONFIG_LEVEL_LOG_LEVEL);
+
+/** @brief The channel level a fully lit primary colour is drawn at. */
+#define LIT ((uint8_t)CONFIG_LEVEL_BRIGHTNESS)
+
+/* The two ends of the colour scale, interpolated by tilt magnitude and latched
+ * to the near end once the board is level.
+ */
+#define BUBBLE_COLOR_FAR  MATRIX_RGB(LIT, 0U, 0U)
+#define BUBBLE_COLOR_NEAR MATRIX_RGB(0U, LIT, 0U)
+
+#define PI_F             3.14159265358979f
+#define DEG_TO_RAD(_deg) ((_deg) * PI_F / 180.0f)
+
+/** @brief Interpolate from @p from to @p to by @p t. */
+static uint8_t lerp_channel(uint8_t from, uint8_t to, float t)
+{
+	return (uint8_t)lroundf((float)from + (((float)to - (float)from) * t));
+}
+
+/** @brief Interpolate from @p from to @p to by @p t, per channel. */
+static struct matrix_rgb lerp_color(struct matrix_rgb from, struct matrix_rgb to, float t)
+{
+	struct matrix_rgb out;
+
+	out.r = lerp_channel(from.r, to.r, t);
+	out.g = lerp_channel(from.g, to.g, t);
+	out.b = lerp_channel(from.b, to.b, t);
+
+	return out;
+}
+
+/**
+ * @brief Decide whether the board counts as level, with hysteresis.
+ *
+ * The latch engages at one angle and releases at a wider one, so a
+ * board balanced on the threshold stays stable instead of flickering
+ * with every noisy sample.
+ *
+ * @param tilt Current attitude.
+ * @param locked Whether the latch was engaged on the previous frame.
+ *
+ * @return Whether the latch is engaged now.
+ */
+static bool level_latched(const struct tilt *tilt, bool locked)
+{
+	/* Compared in sine space, like every other angle in this sample. */
+	const float engage = sinf(DEG_TO_RAD((float)CONFIG_LEVEL_LOCK_TILT / 10.0f));
+	const float release = sinf(
+		DEG_TO_RAD((float)(CONFIG_LEVEL_LOCK_TILT + CONFIG_LEVEL_LOCK_HYSTERESIS) / 10.0f));
+
+	if (!tilt->valid || (CONFIG_LEVEL_LOCK_TILT == 0)) {
+		/* Free fall isn't level; zero disables the latch. */
+		return false;
+	}
+
+	return locked ? (tilt->magnitude <= release) : (tilt->magnitude <= engage);
+}
+
+void bubble_update(const struct matrix *matrix, const struct tilt *tilt, struct bubble *bubble)
+{
+	/* The panel centre the bubble returns to at level. It lands between
+	 * pixels on an even panel and on a pixel on an odd one; both are
+	 * fine as long as it stays fractional.
+	 */
+	const float centre_x = (float)(matrix->width - 1U) * 0.5f;
+	const float centre_y = (float)(matrix->height - 1U) * 0.5f;
+
+	/* Tilt is carried as a sine, so the full scale angle has to become
+	 * one too before the two can be divided.
+	 */
+	const float full_scale = sinf(DEG_TO_RAD((float)CONFIG_LEVEL_FULL_SCALE_TILT));
+
+	/* Colour responds over a much tighter angle than position: it covers
+	 * the last degree or so, where the panel has no resolution left.
+	 */
+	const float color_range = sinf(DEG_TO_RAD((float)CONFIG_LEVEL_COLOR_RANGE_TILT / 10.0f));
+
+	float travel_x = 0.0f;
+	float travel_y = 0.0f;
+
+	bubble->off_scale = false;
+	bubble->proximity = 0.0f;
+
+	/* Reads the previous latch and writes back the new one. */
+	bubble->locked = level_latched(tilt, bubble->locked);
+
+	if (tilt->valid) {
+		float travel;
+
+		travel_x = tilt->x / full_scale;
+		travel_y = tilt->y / full_scale;
+
+		travel = sqrtf((travel_x * travel_x) + (travel_y * travel_y));
+		if (travel > 1.0f) {
+			travel_x /= travel;
+			travel_y /= travel;
+			bubble->off_scale = true;
+		}
+
+		/* One at dead level, zero at the edge of the colour range.
+		 * Stays zero for an invalid attitude, so free fall isn't shown
+		 * as level.
+		 */
+		if (tilt->magnitude < color_range) {
+			bubble->proximity = 1.0f - (tilt->magnitude / color_range);
+		}
+	}
+
+	if (bubble->locked) {
+		/* When latched, snap to the near colour. */
+		bubble->proximity = 1.0f;
+	}
+
+	bubble->x = centre_x + (travel_x * centre_x);
+	bubble->y = centre_y + (travel_y * centre_y);
+}
+
+void bubble_render(struct matrix *matrix, const struct bubble *bubble)
+{
+	/* Use colour to convey additional information once we're at the limits
+	 * of pixel-positioning precision.
+	 */
+	const struct matrix_rgb color =
+		lerp_color(BUBBLE_COLOR_FAR, BUBBLE_COLOR_NEAR, bubble->proximity);
+
+	/* Render the fractional bubble position as a splat with weighted
+	 * intensities to convey a sub-pixel accurate position. This also
+	 * intrinsically handles centering the bubble on matrices with no center
+	 * pixel, instead leaving the four center-most pixels lit evenly.
+	 */
+	matrix_splat(matrix, bubble->x, bubble->y, color);
+}

--- a/samples/display/level/src/bubble.h
+++ b/samples/display/level/src/bubble.h
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LEVEL_BUBBLE_H_
+#define LEVEL_BUBBLE_H_
+
+#include <stdbool.h>
+
+#include "matrix.h"
+#include "tilt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief The state of the level indicator.
+ *
+ * The position is a continuous coordinate in pixel centre space, so the
+ * centre of an eight pixel wide panel is @c 3.5, between two pixels,
+ * and that of a five pixel wide one is @c 2.0, on a pixel. Keeping the
+ * fraction rather than rounding it away is what allows the bubble to be
+ * rendered with sub-pixel accuracy.
+ *
+ * @note This is state, not a fresh result. bubble_update() carries the
+ *       @c locked latch over from one call to the next, so the same
+ *       struct has to be handed back in every frame, and it has to start
+ *       out zeroed.
+ */
+struct bubble {
+	/** Column, in pixel centre coordinates. */
+	float x;
+	/** Row, in pixel centre coordinates. */
+	float y;
+	/**
+	 * @brief How close to level the board is, from 0 to 1.
+	 *
+	 * One at dead level, zero at CONFIG_LEVEL_COLOR_RANGE_TILT and
+	 * beyond, interpolated in between. This drives the colour of the
+	 * bubble, which exists because position alone cannot resolve near
+	 * the middle: the last degree of tilt moves the bubble by a
+	 * fraction of a pixel, too little to see.
+	 *
+	 * Pinned to one while @c locked, and zero whenever the attitude is
+	 * not valid, so that a board in free fall is never reported as
+	 * level.
+	 */
+	float proximity;
+	/**
+	 * @brief Whether the board currently counts as level.
+	 *
+	 * Latched with hysteresis: engages at CONFIG_LEVEL_LOCK_TILT and
+	 * does not release until the board is tipped past that plus
+	 * CONFIG_LEVEL_LOCK_HYSTERESIS. Carried over between calls, which
+	 * is why this struct is state rather than a result.
+	 */
+	bool locked;
+	/** Whether the tilt exceeded full scale and the position was clamped. */
+	bool off_scale;
+};
+
+/**
+ * @brief Bring the bubble up to date for a given attitude.
+ *
+ * The bubble travels away from the centre of the panel in proportion to
+ * the tilt, reaching the rim at CONFIG_LEVEL_FULL_SCALE_TILT degrees.
+ * Beyond full scale it is clamped radially, so it sweeps a disc like the
+ * bubble in a real vial instead of reaching into the corners.
+ *
+ * Its colour is worked out over the much tighter
+ * CONFIG_LEVEL_COLOR_RANGE_TILT, and latches once the board is level.
+ *
+ * @param matrix Initialised matrix, read for its geometry only.
+ * @param tilt Attitude to place the bubble for.
+ * @param bubble Bubble to update, must not be @c NULL, and must be the
+ *               same one as on the previous call so that the latch is
+ *               carried over.
+ */
+void bubble_update(const struct matrix *matrix, const struct tilt *tilt, struct bubble *bubble);
+
+/**
+ * @brief Paint the bubble into the frame buffer.
+ *
+ * Does not clear the frame buffer first, so the caller decides what else
+ * shares the panel.
+ *
+ * @param matrix Initialised matrix.
+ * @param bubble Position to paint at.
+ */
+void bubble_render(struct matrix *matrix, const struct bubble *bubble);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LEVEL_BUBBLE_H_ */

--- a/samples/display/level/src/main.c
+++ b/samples/display/level/src/main.c
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <math.h>
+#include <stdbool.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include "bubble.h"
+#include "matrix.h"
+#include "tilt.h"
+
+LOG_MODULE_REGISTER(level, CONFIG_LEVEL_LOG_LEVEL);
+
+/** @brief The channel level a fully lit primary colour is drawn at. */
+#define LIT ((uint8_t)CONFIG_LEVEL_BRIGHTNESS)
+
+#define RAD_TO_DEG(_rad) ((_rad) * 180.0f / 3.14159265358979f)
+
+/** @brief Render a Kconfig switch as something readable in a log line. */
+#define YESNO(_cfg) (IS_ENABLED(_cfg) ? "yes" : "no")
+
+/**
+ * @brief Show the corner test image for a moment.
+ *
+ * Lights the four corners in four colours to reveal where the origin
+ * of the panel physically sits, which is needed to judge whether the
+ * bubble runs the right way: red top left, green top right, blue
+ * bottom right, white bottom left.
+ */
+static void show_test_image(struct matrix *matrix)
+{
+	const int right = (int)matrix->width - 1;
+	const int bottom = (int)matrix->height - 1;
+
+	if (CONFIG_LEVEL_TEST_IMAGE_MS == 0) {
+		return;
+	}
+
+	matrix_clear(matrix);
+
+	matrix_set_pixel(matrix, 0, 0, MATRIX_RGB(LIT, 0U, 0U));
+	matrix_set_pixel(matrix, right, 0, MATRIX_RGB(0U, LIT, 0U));
+	matrix_set_pixel(matrix, right, bottom, MATRIX_RGB(0U, 0U, LIT));
+	matrix_set_pixel(matrix, 0, bottom, MATRIX_RGB(LIT, LIT, LIT));
+
+	if (matrix_flush(matrix) == 0) {
+		k_sleep(K_MSEC(CONFIG_LEVEL_TEST_IMAGE_MS));
+	}
+}
+
+/**
+ * @brief Report the current attitude and where it puts the bubble.
+ *
+ * Prints the raw sensor frame, the panel-aligned tilt derived from it,
+ * and the pixel that tilt finally lights.
+ */
+static void log_state(const struct tilt *tilt, const struct bubble *bubble)
+{
+	/* Rounding can push the magnitude slightly past one, and asinf()
+	 * of anything above one is NaN.
+	 */
+	const float angle = RAD_TO_DEG(asinf(MIN(tilt->magnitude, 1.0f)));
+
+	LOG_INF("accel %7.3f %7.3f %7.3f m/s^2, |a| %6.3f", (double)tilt->accel[0],
+		(double)tilt->accel[1], (double)tilt->accel[2], (double)tilt->accel_magnitude);
+	LOG_INF("tilt  x %+6.3f y %+6.3f, angle %5.2f deg%s", (double)tilt->x, (double)tilt->y,
+		(double)angle, tilt->valid ? "" : ", INVALID");
+	LOG_INF("dot   %5.2f, %5.2f, proximity %4.2f%s%s", (double)bubble->x, (double)bubble->y,
+		(double)bubble->proximity, bubble->off_scale ? ", off scale" : "",
+		bubble->locked ? ", LEVEL" : "");
+}
+
+int main(void)
+{
+	struct tilt_source source;
+	struct matrix matrix;
+	/* Carries the level latch between frames, so it lives outside the
+	 * loop and starts zeroed.
+	 */
+	struct bubble bubble = {0};
+	int64_t next_log = 0;
+	int ret;
+
+	ret = matrix_init(&matrix);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = tilt_init(&source);
+	if (ret < 0) {
+		return ret;
+	}
+
+	LOG_INF("Level on a %ux%u RGB matrix, %u bytes per pixel, %u ms per frame", matrix.width,
+		matrix.height, (unsigned int)matrix.bpp, (unsigned int)CONFIG_LEVEL_FRAME_INTERVAL);
+	LOG_INF("Inertial sensor is %s, full scale tilt is %u deg", source.dev->name,
+		(unsigned int)CONFIG_LEVEL_FULL_SCALE_TILT);
+	LOG_INF("Axis map: swap-xy %s, invert-x %s, invert-y %s", YESNO(CONFIG_LEVEL_AXIS_SWAP_XY),
+		YESNO(CONFIG_LEVEL_AXIS_INVERT_X), YESNO(CONFIG_LEVEL_AXIS_INVERT_Y));
+	LOG_INF("Filter time constant is %u ms, giving a weight of %.3f per sample",
+		(unsigned int)CONFIG_LEVEL_FILTER_TIME_CONSTANT, (double)source.alpha);
+	LOG_INF("Colour ramps below %u.%u deg, latches level below %u.%u deg, releases at %u.%u "
+		"deg",
+		CONFIG_LEVEL_COLOR_RANGE_TILT / 10U, CONFIG_LEVEL_COLOR_RANGE_TILT % 10U,
+		CONFIG_LEVEL_LOCK_TILT / 10U, CONFIG_LEVEL_LOCK_TILT % 10U,
+		(CONFIG_LEVEL_LOCK_TILT + CONFIG_LEVEL_LOCK_HYSTERESIS) / 10U,
+		(CONFIG_LEVEL_LOCK_TILT + CONFIG_LEVEL_LOCK_HYSTERESIS) % 10U);
+
+	show_test_image(&matrix);
+
+	while (true) {
+		struct tilt tilt;
+		int64_t now;
+
+		ret = tilt_read(&source, &tilt);
+		if (ret < 0) {
+			return ret;
+		}
+
+		bubble_update(&matrix, &tilt, &bubble);
+
+		/* Throttle the log without slowing the sampling. */
+		now = k_uptime_get();
+		if (now >= next_log) {
+			log_state(&tilt, &bubble);
+			next_log = now + CONFIG_LEVEL_SENSOR_LOG_INTERVAL;
+		}
+
+		matrix_clear(&matrix);
+		bubble_render(&matrix, &bubble);
+
+		ret = matrix_flush(&matrix);
+		if (ret < 0) {
+			return ret;
+		}
+
+		k_sleep(K_MSEC(CONFIG_LEVEL_FRAME_INTERVAL));
+	}
+}

--- a/samples/display/level/src/matrix.c
+++ b/samples/display/level/src/matrix.c
@@ -1,0 +1,240 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <math.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/display.h>
+#include <zephyr/logging/log.h>
+
+#include "matrix.h"
+
+LOG_MODULE_DECLARE(level, CONFIG_LEVEL_LOG_LEVEL);
+
+#if !DT_HAS_CHOSEN(zephyr_display)
+#error "This sample needs an RGB matrix assigned to the chosen zephyr,display node"
+#endif
+
+#define MATRIX_NODE   DT_CHOSEN(zephyr_display)
+#define MATRIX_WIDTH  DT_PROP(MATRIX_NODE, width)
+#define MATRIX_HEIGHT DT_PROP(MATRIX_NODE, height)
+
+/* The frame buffer is sized at build time for the worst supported case,
+ * ARGB_8888 at four bytes per pixel. The format in use is queried at
+ * run time and may be narrower.
+ */
+#define MATRIX_MAX_BPP 4U
+#define FRAME_BUF_SIZE ((size_t)MATRIX_WIDTH * MATRIX_HEIGHT * MATRIX_MAX_BPP)
+
+static uint8_t frame_buf[FRAME_BUF_SIZE];
+
+/** @brief Bytes per pixel, or 0 if the format is not supported. */
+static size_t bytes_per_pixel(enum display_pixel_format format)
+{
+	switch (format) {
+	case PIXEL_FORMAT_ARGB_8888:
+		return 4U;
+	case PIXEL_FORMAT_RGB_888:
+		return 3U;
+	default:
+		return 0U;
+	}
+}
+
+/** @brief Write one colour to the frame buffer at @p dst. */
+static void put_pixel(uint8_t *dst, enum display_pixel_format format, struct matrix_rgb color)
+{
+	if (format == PIXEL_FORMAT_ARGB_8888) {
+		uint32_t argb = 0xFF000000U | ((uint32_t)color.r << 16) | ((uint32_t)color.g << 8) |
+				(uint32_t)color.b;
+
+		/* Unaligned native store, matching how the LED strip matrix
+		 * driver reads the pixel back.
+		 */
+		memcpy(dst, &argb, sizeof(argb));
+	} else {
+		dst[0] = color.r;
+		dst[1] = color.g;
+		dst[2] = color.b;
+	}
+}
+
+int matrix_init(struct matrix *matrix)
+{
+	const struct device *const dev = DEVICE_DT_GET(MATRIX_NODE);
+	struct display_capabilities caps;
+	int ret;
+
+	if (!device_is_ready(dev)) {
+		LOG_ERR("Display device %s is not ready", dev->name);
+		return -ENODEV;
+	}
+
+	display_get_capabilities(dev, &caps);
+
+	matrix->dev = dev;
+	matrix->width = caps.x_resolution;
+	matrix->height = caps.y_resolution;
+	matrix->format = caps.current_pixel_format;
+	matrix->bpp = bytes_per_pixel(matrix->format);
+	matrix->buf = frame_buf;
+
+	if (matrix->bpp == 0U) {
+		LOG_ERR("Pixel format %d is not supported, need RGB_888 or ARGB_8888",
+			matrix->format);
+		return -ENOTSUP;
+	}
+
+	if ((matrix->width > MATRIX_WIDTH) || (matrix->height > MATRIX_HEIGHT)) {
+		LOG_ERR("Display is %ux%u, but the frame buffer only holds %ux%u", matrix->width,
+			matrix->height, (unsigned int)MATRIX_WIDTH, (unsigned int)MATRIX_HEIGHT);
+		return -ENOMEM;
+	}
+
+	/* The LED strip matrix driver does not implement blanking,
+	 * so -ENOSYS is not an error.
+	 */
+	ret = display_blanking_off(dev);
+	if ((ret < 0) && (ret != -ENOSYS)) {
+		LOG_ERR("Failed to switch off display blanking (%d)", ret);
+		return ret;
+	}
+
+	matrix->desc.width = matrix->width;
+	matrix->desc.height = matrix->height;
+	matrix->desc.pitch = matrix->width;
+	matrix->desc.buf_size = (uint32_t)matrix->width * matrix->height * matrix->bpp;
+	matrix->desc.frame_incomplete = false;
+
+	matrix_clear(matrix);
+
+	return 0;
+}
+
+/** @brief Read one colour from the frame buffer at @p src. */
+static void get_pixel(const uint8_t *src, enum display_pixel_format format, struct matrix_rgb *out)
+{
+	if (format == PIXEL_FORMAT_ARGB_8888) {
+		uint32_t argb;
+
+		memcpy(&argb, src, sizeof(argb));
+
+		out->r = (uint8_t)((argb >> 16) & 0xFFU);
+		out->g = (uint8_t)((argb >> 8) & 0xFFU);
+		out->b = (uint8_t)(argb & 0xFFU);
+	} else {
+		out->r = src[0];
+		out->g = src[1];
+		out->b = src[2];
+	}
+}
+
+/** @brief Address of one pixel in the frame buffer, or NULL if off panel. */
+static uint8_t *pixel_at(struct matrix *matrix, int x, int y)
+{
+	if ((x < 0) || (y < 0) || (x >= (int)matrix->width) || (y >= (int)matrix->height)) {
+		return NULL;
+	}
+
+	return &matrix->buf[(((size_t)y * matrix->width) + (size_t)x) * matrix->bpp];
+}
+
+/** @brief Sum two channel levels, stopping at full drive. */
+static uint8_t add_saturating(uint8_t a, uint8_t b)
+{
+	uint16_t sum = (uint16_t)a + (uint16_t)b;
+
+	return (sum > 255U) ? 255U : (uint8_t)sum;
+}
+
+/** @brief Dim a colour to @p weight of its full strength. */
+static struct matrix_rgb scale_color(struct matrix_rgb color, float weight)
+{
+	struct matrix_rgb out;
+
+	out.r = (uint8_t)lroundf((float)color.r * weight);
+	out.g = (uint8_t)lroundf((float)color.g * weight);
+	out.b = (uint8_t)lroundf((float)color.b * weight);
+
+	return out;
+}
+
+void matrix_set_pixel(struct matrix *matrix, int x, int y, struct matrix_rgb color)
+{
+	uint8_t *dst = pixel_at(matrix, x, y);
+
+	if (dst == NULL) {
+		return;
+	}
+
+	put_pixel(dst, matrix->format, color);
+}
+
+void matrix_add_pixel(struct matrix *matrix, int x, int y, struct matrix_rgb color)
+{
+	uint8_t *dst = pixel_at(matrix, x, y);
+	struct matrix_rgb current;
+
+	if (dst == NULL) {
+		return;
+	}
+
+	get_pixel(dst, matrix->format, &current);
+
+	current.r = add_saturating(current.r, color.r);
+	current.g = add_saturating(current.g, color.g);
+	current.b = add_saturating(current.b, color.b);
+
+	put_pixel(dst, matrix->format, current);
+}
+
+void matrix_splat(struct matrix *matrix, float x, float y, struct matrix_rgb color)
+{
+	/* The pixel the point falls into, and how far into it the point sits
+	 * along each axis. A fraction of zero means the point is dead centre
+	 * on that pixel and its neighbour gets nothing.
+	 */
+	const int x0 = (int)floorf(x);
+	const int y0 = (int)floorf(y);
+	const float fx = x - floorf(x);
+	const float fy = y - floorf(y);
+
+	/* Bilinear coverage of the four pixels the point straddles. These
+	 * sum to one, which makes the perceived total brightness constant.
+	 */
+	matrix_add_pixel(matrix, x0, y0, scale_color(color, (1.0f - fx) * (1.0f - fy)));
+	matrix_add_pixel(matrix, x0 + 1, y0, scale_color(color, fx * (1.0f - fy)));
+	matrix_add_pixel(matrix, x0, y0 + 1, scale_color(color, (1.0f - fx) * fy));
+	matrix_add_pixel(matrix, x0 + 1, y0 + 1, scale_color(color, fx * fy));
+}
+
+void matrix_fill(struct matrix *matrix, struct matrix_rgb color)
+{
+	uint8_t *dst = matrix->buf;
+
+	for (size_t i = 0U; i < ((size_t)matrix->width * matrix->height); i++) {
+		put_pixel(dst, matrix->format, color);
+		dst += matrix->bpp;
+	}
+}
+
+void matrix_clear(struct matrix *matrix)
+{
+	matrix_fill(matrix, MATRIX_BLACK);
+}
+
+int matrix_flush(struct matrix *matrix)
+{
+	int ret;
+
+	ret = display_write(matrix->dev, 0, 0, &matrix->desc, matrix->buf);
+	if (ret < 0) {
+		LOG_ERR("Failed to write a frame to the display (%d)", ret);
+	}
+
+	return ret;
+}

--- a/samples/display/level/src/matrix.h
+++ b/samples/display/level/src/matrix.h
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LEVEL_MATRIX_H_
+#define LEVEL_MATRIX_H_
+
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/display.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief A colour in the sRGB cube, one byte per channel. */
+struct matrix_rgb {
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+};
+
+/** @brief Compound literal for an opaque sRGB colour. */
+#define MATRIX_RGB(_r, _g, _b) ((struct matrix_rgb){.r = (_r), .g = (_g), .b = (_b)})
+
+/** @brief The colour of an unlit pixel. */
+#define MATRIX_BLACK MATRIX_RGB(0U, 0U, 0U)
+
+/**
+ * @brief An RGB matrix driven through the display driver API.
+ *
+ * Everything in here is filled in by matrix_init() and should be treated
+ * as read only afterwards. Drawing goes through matrix_set_pixel() and
+ * friends, which paint into an off screen frame buffer, and reaches the
+ * panel only once matrix_flush() is called.
+ */
+struct matrix {
+	/** The underlying display device. */
+	const struct device *dev;
+	/** Panel geometry as reported by the driver, in pixels. */
+	uint16_t width;
+	uint16_t height;
+	/** Pixel format the driver is currently configured for. */
+	enum display_pixel_format format;
+	/** Bytes one pixel occupies in the frame buffer. */
+	size_t bpp;
+	/** Descriptor handed to display_write(), prepared once. */
+	struct display_buffer_descriptor desc;
+	/** Off screen frame buffer, owned by the matrix module. */
+	uint8_t *buf;
+};
+
+/**
+ * @brief Bring up the chosen RGB matrix and its frame buffer.
+ *
+ * Fetches the panel geometry and pixel format from the driver, checks
+ * that both fit what this sample can render, switches blanking off and
+ * clears the frame buffer. The panel itself is left untouched until the
+ * first matrix_flush().
+ *
+ * @param matrix Destination descriptor, must not be @c NULL.
+ *
+ * @retval 0 On success.
+ * @retval -ENODEV If the display device is not ready.
+ * @retval -ENOTSUP If the pixel format is neither RGB_888 nor ARGB_8888.
+ * @retval -ENOMEM If the panel is larger than the compiled in frame buffer.
+ * @retval -errno Otherwise, as reported by the display driver.
+ */
+int matrix_init(struct matrix *matrix);
+
+/**
+ * @brief Paint a single pixel into the frame buffer.
+ *
+ * Coordinates outside the panel are silently ignored, so callers may
+ * clip lazily.
+ *
+ * @param matrix Initialised matrix descriptor.
+ * @param x Column, counted from the left edge.
+ * @param y Row, counted from the top edge.
+ * @param color Colour to write.
+ */
+void matrix_set_pixel(struct matrix *matrix, int x, int y, struct matrix_rgb color);
+
+/**
+ * @brief Add light to a single pixel of the frame buffer.
+ *
+ * Like matrix_set_pixel(), but sums into whatever is already there and
+ * saturates at full drive rather than overwriting, which lets several
+ * things share a pixel.
+ *
+ * Coordinates outside the panel are silently ignored.
+ *
+ * @param matrix Initialised matrix descriptor.
+ * @param x Column, counted from the left edge.
+ * @param y Row, counted from the top edge.
+ * @param color Colour to add.
+ */
+void matrix_add_pixel(struct matrix *matrix, int x, int y, struct matrix_rgb color);
+
+/**
+ * @brief Paint a point of light at a fractional position.
+ *
+ * Spreads @p color over the up to four pixels that the point at
+ * (@p x, @p y) straddles, weighting each by how much of it the point
+ * covers. The weights are bilinear and sum to one, so the panel stays
+ * equally bright wherever the point sits, and the eye reads its
+ * position from the balance between the lit pixels.
+ *
+ * This buys sub-pixel resolution on a panel with very few pixels but
+ * plenty of brightness steps, and it needs no special case for an even
+ * number of pixels: a point at (3.5, 3.5) simply lights the four middle
+ * pixels equally, while on an odd-sided panel a point at (2.0, 2.0)
+ * lights the single middle one.
+ *
+ * Contributions falling outside the panel are silently dropped.
+ *
+ * @param matrix Initialised matrix descriptor.
+ * @param x Column, in pixel centre coordinates.
+ * @param y Row, in pixel centre coordinates.
+ * @param color Colour of the point at full weight.
+ */
+void matrix_splat(struct matrix *matrix, float x, float y, struct matrix_rgb color);
+
+/**
+ * @brief Paint every pixel of the frame buffer in one colour.
+ *
+ * @param matrix Initialised matrix descriptor.
+ * @param color Colour to write.
+ */
+void matrix_fill(struct matrix *matrix, struct matrix_rgb color);
+
+/**
+ * @brief Paint every pixel of the frame buffer black.
+ *
+ * @param matrix Initialised matrix descriptor.
+ */
+void matrix_clear(struct matrix *matrix);
+
+/**
+ * @brief Push the frame buffer out to the panel.
+ *
+ * @param matrix Initialised matrix descriptor.
+ *
+ * @retval 0 On success.
+ * @retval -errno Otherwise, as reported by the display driver.
+ */
+int matrix_flush(struct matrix *matrix);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LEVEL_MATRIX_H_ */

--- a/samples/display/level/src/tilt.c
+++ b/samples/display/level/src/tilt.c
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <math.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include "tilt.h"
+
+LOG_MODULE_DECLARE(level, CONFIG_LEVEL_LOG_LEVEL);
+
+#if !DT_NODE_EXISTS(DT_ALIAS(accel0))
+#error "This sample needs an inertial sensor assigned to the accel0 alias"
+#endif
+
+#define IMU_NODE DT_ALIAS(accel0)
+
+/* Below this the acceleration vector is too short to define an attitude,
+ * as in free fall. A board at rest reads about ten times this.
+ */
+#define ACCEL_MIN_MAGNITUDE 1.0f
+
+/**
+ * @brief Weight to give each new sample in the low pass filter.
+ *
+ * Kconfig sets a time constant rather than a raw weight, because a
+ * weight only means something in combination with the sampling rate:
+ * converting here keeps the smoothing the same if the frame interval
+ * is ever changed.
+ *
+ * For a first order low pass sampled every @c dt, the weight that gives
+ * a time constant of @c tau is 1 - e^(-dt/tau).
+ */
+static float filter_alpha(void)
+{
+	if (CONFIG_LEVEL_FILTER_TIME_CONSTANT <= 0) {
+		/* Filtering disabled: pass every sample through
+		 * unchanged.
+		 */
+		return 1.0f;
+	}
+
+	return 1.0f -
+	       expf(-(float)CONFIG_LEVEL_FRAME_INTERVAL / (float)CONFIG_LEVEL_FILTER_TIME_CONSTANT);
+}
+
+int tilt_init(struct tilt_source *src)
+{
+	src->dev = DEVICE_DT_GET(IMU_NODE);
+	src->alpha = filter_alpha();
+	src->primed = false;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(src->filtered); i++) {
+		src->filtered[i] = 0.0f;
+	}
+
+	if (!device_is_ready(src->dev)) {
+		LOG_ERR("Sensor device %s is not ready", src->dev->name);
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+int tilt_read(struct tilt_source *src, struct tilt *out)
+{
+	struct sensor_value accel[3];
+	float x;
+	float y;
+	int ret;
+
+	ret = sensor_sample_fetch(src->dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to fetch a sample from %s (%d)", src->dev->name, ret);
+		return ret;
+	}
+
+	ret = sensor_channel_get(src->dev, SENSOR_CHAN_ACCEL_XYZ, accel);
+	if (ret < 0) {
+		LOG_ERR("Failed to read acceleration from %s (%d)", src->dev->name, ret);
+		return ret;
+	}
+
+	for (size_t i = 0U; i < ARRAY_SIZE(out->accel); i++) {
+		const float sample = sensor_value_to_float(&accel[i]);
+
+		if (src->primed) {
+			/* Filter the acceleration vector, before
+			 * normalisation, so the smoothing behaves the
+			 * same at any tilt.
+			 */
+			src->filtered[i] += src->alpha * (sample - src->filtered[i]);
+		} else {
+			/* Seed from the first reading, so the bubble starts
+			 * where the board is instead of at panel centre.
+			 */
+			src->filtered[i] = sample;
+		}
+
+		out->accel[i] = src->filtered[i];
+	}
+
+	src->primed = true;
+
+	out->accel_magnitude =
+		sqrtf((out->accel[0] * out->accel[0]) + (out->accel[1] * out->accel[1]) +
+		      (out->accel[2] * out->accel[2]));
+
+	/* Map the sensor frame onto the panel frame. The eight combinations
+	 * of these three switches cover every way a sensor can be mounted
+	 * relative to the display; the right one is measured per board and
+	 * defaulted in Kconfig.
+	 */
+	if (IS_ENABLED(CONFIG_LEVEL_AXIS_SWAP_XY)) {
+		x = out->accel[1];
+		y = out->accel[0];
+	} else {
+		x = out->accel[0];
+		y = out->accel[1];
+	}
+
+	if (IS_ENABLED(CONFIG_LEVEL_AXIS_INVERT_X)) {
+		x = -x;
+	}
+
+	if (IS_ENABLED(CONFIG_LEVEL_AXIS_INVERT_Y)) {
+		y = -y;
+	}
+
+	if (out->accel_magnitude < ACCEL_MIN_MAGNITUDE) {
+		out->x = 0.0f;
+		out->y = 0.0f;
+		out->magnitude = 0.0f;
+		out->valid = false;
+
+		return 0;
+	}
+
+	/* Normalising by the measured vector length, rather than by a fixed
+	 * 1 g, turns the components into plain sines of the tilt angle:
+	 * bounded to [-1, 1], and valid even while the board is moving.
+	 */
+	out->x = x / out->accel_magnitude;
+	out->y = y / out->accel_magnitude;
+	out->magnitude = sqrtf((out->x * out->x) + (out->y * out->y));
+	out->valid = true;
+
+	return 0;
+}

--- a/samples/display/level/src/tilt.h
+++ b/samples/display/level/src/tilt.h
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LEVEL_TILT_H_
+#define LEVEL_TILT_H_
+
+#include <stdbool.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief The attitude of the board, derived from one accelerometer reading.
+ *
+ * The in-plane components are the sine of the tilt angle projected onto
+ * each panel axis, bounded to [-1, 1], and already mapped into the
+ * coordinate system of the panel: @c x grows towards the right edge of
+ * the display and @c y towards the bottom edge, however the sensor is
+ * mounted.
+ */
+struct tilt {
+	/** In-plane component along the panel X axis, as sin of the angle. */
+	float x;
+	/** In-plane component along the panel Y axis, as sin of the angle. */
+	float y;
+	/** Length of the in-plane component, equal to sin of the total tilt. */
+	float magnitude;
+	/**
+	 * @brief Smoothed reading in the sensor frame, in m/s².
+	 *
+	 * This is the filtered vector the rest of the sample runs on, not
+	 * the raw sample from the sensor. Set the filter time constant
+	 * to zero for the raw reading.
+	 */
+	float accel[3];
+	/** Length of the raw reading, in m/s². Around 9.81 when at rest. */
+	float accel_magnitude;
+	/**
+	 * @brief Whether the in-plane components mean anything.
+	 *
+	 * Cleared when the acceleration vector is too short to define an
+	 * attitude, as in free fall. The components then read zero, which
+	 * parks the bubble in the centre.
+	 */
+	bool valid;
+};
+
+/**
+ * @brief State of one accelerometer feeding the level.
+ *
+ * Allocated by the caller, filled in by tilt_init(), and then owned by
+ * tilt_read(), which keeps the low pass filter state in here between
+ * calls.
+ */
+struct tilt_source {
+	/** The underlying sensor device. */
+	const struct device *dev;
+	/**
+	 * @brief Weight given to each new sample by the low pass filter.
+	 *
+	 * Derived once from the configured time constant and the frame
+	 * interval. A weight of one means no filtering.
+	 */
+	float alpha;
+	/** Smoothed acceleration, in the sensor frame and in m/s². */
+	float filtered[3];
+	/** Whether @c filtered has been seeded with a first reading yet. */
+	bool primed;
+};
+
+/**
+ * @brief Bind to the accelerometer behind the @c accel0 alias.
+ *
+ * @param src Destination context, must not be @c NULL.
+ *
+ * @retval 0 On success.
+ * @retval -ENODEV If the sensor device is not ready.
+ */
+int tilt_init(struct tilt_source *src);
+
+/**
+ * @brief Take one reading and reduce it to a panel aligned attitude.
+ *
+ * @param src Initialised context.
+ * @param out Destination attitude, must not be @c NULL.
+ *
+ * @retval 0 On success, including the case where @p out is not valid.
+ * @retval -errno Otherwise, as reported by the sensor driver.
+ */
+int tilt_read(struct tilt_source *src, struct tilt *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LEVEL_TILT_H_ */

--- a/samples/display/level/tests.yaml
+++ b/samples/display/level/tests.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  description: Digital spirit level on an RGB LED matrix
+  name: level
+common:
+  tags:
+    - bridle
+    - drivers
+    - display
+    - led_strip
+    - sensors
+  sysbuild: false
+  build_only: true
+  depends_on:
+    - i2c
+  filter: dt_chosen_enabled("zephyr,display") and
+          dt_compat_enabled("led-strip-matrix") and
+          dt_alias_exists("accel0")
+tests:
+  bridle.sample.level:
+    platform_allow:
+      - waveshare_rp2350_matrix/rp2350a/hazard3
+      - waveshare_rp2350_matrix/rp2350a/m33
+    integration_platforms:
+      - waveshare_rp2350_matrix/rp2350a/hazard3
+      - waveshare_rp2350_matrix/rp2350a/m33


### PR DESCRIPTION
Adds two samples demonstrating use of the display API for driving small LED matrices using application-side frame buffers, including one which incorporates accelerometer sensor data and primitive anti-aliasing for perceived sub-pixel display accuracy.