### PR TITLE
samples: display: add colorful RGB gradient sample

### DIFF
--- a/samples/display/colorful/CMakeLists.txt
+++ b/samples/display/colorful/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+# Standard Bridle application boilerplate, includes Zephyr.
+find_package(Bridle REQUIRED HINTS $ENV{BRIDLE_BASE})
+project("Colorful LCD or LED strip (matrix) as display" VERSION 0.1)
+
+target_sources(app PRIVATE src/main.c src/colorful.c)

--- a/samples/display/colorful/Kconfig
+++ b/samples/display/colorful/Kconfig
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+#
+# Based on Zephyr upstream display driver sample:
+# Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+# Copyright (c) 2025 NXP
+#
+# Private config options for colorful sample
+
+mainmenu "Colorful sample application"
+
+source "Kconfig.zephyr"
+
+# Workaround for not being able to have commas in macro arguments
+UINT8_RANGE := 0, $(UINT8_MAX)
+UINT8_MIN_HEX := $(min_hex, $(UINT8_RANGE))
+UINT8_MAX_HEX := $(max_hex, $(UINT8_RANGE))
+UINT8_6PP_HEX := $(div_hex, $(UINT8_MAX), 16)
+
+config SAMPLE_MAX_INTENSITY
+	hex "Maximum intensity in all color channels"
+	default $(UINT8_6PP_HEX) if LED_STRIP_MATRIX
+	default $(UINT8_MAX_HEX)
+	range $(UINT8_MIN_HEX) $(UINT8_MAX_HEX)
+	help
+	  Some displays, particularly those based on LED technology,
+	  require a reduced brightness range per color channel for
+	  safety reasons. This ensures that LED matrix displays do
+	  not draw excessive electrical current and that the luminous
+	  flux they generate does not pose a risk of physical injury
+	  (e.g., glared by direct eye exposure to LEDs).
+
+config SAMPLE_INIT_INTENSITY
+	hex "Initial intensity in all color channels"
+	default $(UINT8_MIN_HEX) if LED_STRIP_MATRIX
+	range $(UINT8_MIN_HEX) $(UINT8_MIN_HEX) if LED_STRIP_MATRIX
+	default $(UINT8_MAX_HEX)
+	range $(UINT8_MAX_HEX) $(UINT8_MAX_HEX)
+	help
+	  Some displays, particularly those based on LED technology,
+	  do not require initialization with a white background. From
+	  an energy efficiency standpoint and to avoid other well known
+	  disruptive effects, the background of this type of displays
+	  should be initialized as black (i.e., with the LEDs turned off).
+
+config SAMPLE_BUFFER_ADDR_ALIGN
+	int "The display buffer address alignment"
+	default 8 if 64BIT
+	default 8 if DISPLAY_MCUX_ELCDIF
+	default 4
+
+config HEAP_MEM_POOL_ADD_SIZE_SAMPLE
+	int "Sample maximum heap allocated buffer size"
+	default 4096
+	help
+	  Maximum size of the buffer for rendering one line of
+	  1024 pixels, each 4 bytes wide (ARGB-8888).

--- a/samples/display/colorful/README.rst
+++ b/samples/display/colorful/README.rst
@@ -1,0 +1,244 @@
+.. _colorful-sample:
+
+Colorful
+########
+
+Draw an RGB color gradient on a display device.
+
+Overview
+********
+
+This sample uses the :external+zephyr:ref:`display API <display_api>`
+to render an RGB color gradient across the entire display.
+
+With most display drivers, the RGB color gradient runs across the entire
+screen, from red through yellow to green, then from green through cyan to
+blue, and finally from blue through magenta back to red. This cycle repeats
+endlessly and changes the color of all pixels at once. It is not a static
+representation of an RGB color gradient; the colors simply cycle through.
+
+.. raw:: html
+
+   <style>
+     .zephyr-display-sample {
+       position: relative;
+       width: 320px;
+       height: 240px;
+       margin: auto;
+       background: white;
+       border: 1px solid #ccc;
+       box-sizing: border-box;
+     }
+
+     .zephyr-display-sample .entire {
+       position: absolute;
+       width: 318px;
+       height: 238px;
+     }
+
+     /* RGB variant */
+     .zephyr-display-sample--rgb .cg {
+       top: 0;
+       left: 0;
+       background: white;
+       animation: zephyr-display-rgb-toggle 9s linear infinite;
+     }
+
+     /* Mono variant */
+     .zephyr-display-sample--mono .cg {
+       top: 0;
+       left: 0;
+       background: white;
+       animation: zephyr-display-gray-toggle 9s linear infinite;
+     }
+
+     /* 1bpp variant */
+     .zephyr-display-sample--1bpp .cg {
+       top: 0;
+       left: 0;
+       background: white;
+       animation: zephyr-display-bw-toggle 0.6s steps(2, jump-none) infinite;
+     }
+
+     @keyframes zephyr-display-bw-toggle {
+       from { background-color: black; }
+       to   { background-color: white; }
+     }
+
+     /* Quick RGB to luminance: Y = (2 * r + 5 * g + 1 * b) >> 3 */
+     @keyframes zephyr-display-gray-toggle {
+       0%, 100% {
+         /* rgb:#FF0000 -> Y:#3F3F3F */
+         background-color: rgb(63, 63, 63);
+       }
+       16% {
+         /* rgb:#7F7F00 -> Y:#6F6F6F */
+         background-color: rgb(111, 111, 111);
+       }
+       32% {
+         /* rgb:#00FF00 -> Y:#9F9F9F */
+         background-color: rgb(159, 159, 159);
+       }
+       50% {
+         /* rgb:#007F7F -> Y:#5F5F5F */
+         background-color: rgb(95, 95, 95);
+       }
+       66% {
+         /* rgb:#0000FF -> Y:#1F1F1F */
+         background-color: rgb(31, 31, 31);
+       }
+       82% {
+         /* rgb:#7F007F -> Y:#2F2F2F */
+         background-color: rgb(47, 47, 47);
+       }
+     }
+
+     @keyframes zephyr-display-rgb-toggle {
+       0%, 100% {
+         /* rgb:#FF0000 */
+         background-color: rgb(255, 0, 0);
+       }
+       16% {
+         /* rgb:#7F7F00 */
+         background-color: rgb(127, 127, 0);;
+       }
+       32% {
+         /* rgb:#00FF00 */
+         background-color: rgb(0, 255, 0);;
+       }
+       50% {
+         /* rgb:#007F7F */
+         background-color: rgb(0, 127, 127);;
+       }
+       66% {
+         /* rgb:#0000FF */
+         background-color: rgb(0, 0, 255);;
+       }
+       82% {
+         /* rgb:#7F007F */
+         background-color: rgb(127, 0, 127);;
+       }
+     }
+   </style>
+
+.. tabs::
+
+   .. tab:: RGB
+
+      .. raw:: html
+
+         <figure class="zephyr-display-sample-wrap">
+           <div class="zephyr-display-sample zephyr-display-sample--rgb" aria-hidden="true">
+             <div class="entire cg"></div>
+           </div>
+           <figcaption>
+             <p>
+               <span class="caption-text">
+                Typical RGB output at 320x240: color gradient from red across dark yellow to green,
+                across dark cyan to blue, across dark magenta back to red.
+               </span>
+             </p>
+           </figcaption>
+         </figure>
+
+   .. tab:: Grayscale
+
+      On displays using a multi-bit luminance format (for example :c:enumerator:`PIXEL_FORMAT_L_8`),
+      the entire screen runs over different grey level between black and white (color luminance).
+      Other multi-bit monochrome formats behave similarly (different greys).
+
+      .. raw:: html
+
+         <figure class="zephyr-display-sample-wrap">
+           <div class="zephyr-display-sample zephyr-display-sample--mono" aria-hidden="true">
+             <div class="entire cg"></div>
+           </div>
+           <figcaption>
+             <p>
+               <span class="caption-text">
+                Grayscale-style; entire screen animates through different greys (color luminance).
+               </span>
+             </p>
+           </figcaption>
+         </figure>
+
+   .. tab:: 1 bpp
+
+      On displays with 1 bit per pixel, the greyscale animation of the entire screen will appear as
+      flickering between black and white.
+
+      .. raw:: html
+
+         <figure class="zephyr-display-sample-wrap">
+           <div class="zephyr-display-sample zephyr-display-sample--1bpp" aria-hidden="true">
+             <div class="entire cg"></div>
+           </div>
+          <figcaption>
+             <p>
+               <span class="caption-text">
+               1 bpp: entire screen animates flickering between fore- and background color (black
+               for <code>MONO01</code>, white for <code>MONO10</code> on a black screen).
+               </span>
+             </p>
+          </figcaption>
+         </figure>
+
+   .. tab:: E-paper
+
+      By querying the display controller's capabilities, it is possible to determine if the display
+      is an e-paper display by checking if the :c:enumerator:`SCREEN_INFO_EPD` bit is set in the
+      :c:member:`display_capabilities.screen_info`.
+
+      For such displays, the color of the entire screen will change at a much slower rate than
+      on a typical LCD, to align with the typical refresh rate of e-ink technologies.
+
+Building and Running
+********************
+
+As this is a generic sample it should work with any display supported by Zephyr.
+
+Below is an example on how to build for a :external+zephyr:zephyr:board:`nrf52840dk`
+board with a :external+zephyr:ref:`adafruit_2_8_tft_touch_v2`.
+
+.. zephyr-app-commands::
+   :app: bridle/samples/display/colorful
+   :build-dir: colorful
+   :board: nrf52840dk/nrf52840
+   :shield: adafruit_2_8_tft_touch_v2
+   :goals: build
+   :compact:
+
+For testing purpose without the need of any hardware, the
+:external+zephyr:zephyr:board:`native_sim/native/64 <native_sim>`
+board is also supported and can be built as follows:
+
+.. zephyr-app-commands::
+   :app: bridle/samples/display/colorful
+   :build-dir: colorful
+   :board: native_sim/native/64
+   :goals: run
+   :compact:
+
+Twister test suites
+===================
+
+To run the test with twister on emulated or dummy hardware,
+use the following command:
+
+.. code-block:: shell
+
+   west twister -v -X fixture_display -T bridle/samples/display/colorful -s sample.display.colorful.sdl -s sample.display.colorful.dummy
+
+To run all test with twister, use the following command:
+
+.. code-block:: shell
+
+   west twister -v -T bridle/samples/display/colorful
+
+List of Arduino-based display shields
+*************************************
+
+- :external+zephyr:ref:`adafruit_2_8_tft_touch_v2`
+- :external+zephyr:ref:`ssd1306_128_shield`
+- :external+zephyr:ref:`st7789v_generic`
+- :external+zephyr:ref:`waveshare_epaper`

--- a/samples/display/colorful/dummy_dc.overlay
+++ b/samples/display/colorful/dummy_dc.overlay
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on Zephyr upstream display driver sample:
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ */
+
+/ {
+	chosen {
+		zephyr,display = &dummy_dc;
+	};
+
+	dummy_dc: dummy_dc {
+		compatible = "zephyr,dummy-dc";
+		height = <240>;
+		width = <320>;
+	};
+};

--- a/samples/display/colorful/prj.conf
+++ b/samples/display/colorful/prj.conf
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LOG=y
+CONFIG_DISPLAY=y

--- a/samples/display/colorful/src/colorful.c
+++ b/samples/display/colorful/src/colorful.c
@@ -1,0 +1,394 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on Zephyr upstream display driver sample:
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ * Copyright (c) 2025 NXP
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/display.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/sys/byteorder.h>
+
+#ifdef CONFIG_ARCH_POSIX
+#include "posix_board_if.h"
+#endif
+
+#include "colorful.h"
+
+typedef void (*fill_buffer)(uint8_t red_lumina, uint8_t green, uint8_t blue, uint8_t *buf,
+			    size_t buf_size, enum display_pixel_format fmt);
+
+static inline uint8_t fast_rgb2y(uint8_t red, uint8_t green, uint8_t blue)
+{
+	/* Digital ITU BT.601 Luminance (relative):
+	 *
+	 *    Y = 0.299 * R + 0.587 * G + 0.114 * B
+	 *
+	 * Details on and fast approximation from:
+	 *    - https://www.scantips.com/lumin.html
+	 *    - https://www.songho.ca/dsp/luminance/luminance.html#fast
+	 */
+	uint16_t lumina = (2 * (uint16_t)red + 5 * (uint16_t)green + 1 * (uint16_t)blue) >> 3;
+
+	return (uint8_t)(lumina & 0xFFu);
+}
+
+static void fill_buffer_argb8888(uint8_t r, uint8_t g, uint8_t b, uint8_t *buf, size_t buf_size,
+				 enum display_pixel_format fmt)
+{
+	uint8_t a = 0xFFu;
+	uint32_t color;
+
+	switch (fmt) {
+	case PIXEL_FORMAT_ABGR_8888:
+		color = (uint32_t)a << 24 | (uint32_t)b << 16 | (uint32_t)g << 8 | r;
+		break;
+	case PIXEL_FORMAT_RGBA_8888:
+		color = (uint32_t)r << 24 | (uint32_t)g << 16 | (uint32_t)b << 8 | a;
+		break;
+	case PIXEL_FORMAT_BGRA_8888:
+		color = (uint32_t)b << 24 | (uint32_t)g << 16 | (uint32_t)r << 8 | a;
+		break;
+	default: /* PIXEL_FORMAT_ARGB_8888 / PIXEL_FORMAT_XRGB_8888 */
+		color = (uint32_t)a << 24 | (uint32_t)r << 16 | (uint32_t)g << 8 | b;
+		break;
+	}
+
+	for (size_t idx = 0; idx < buf_size; idx += 4) {
+		*((uint32_t *)(buf + idx)) = sys_cpu_to_le32(color);
+	}
+}
+
+static void fill_buffer_rgb888(uint8_t r, uint8_t g, uint8_t b, uint8_t *buf, size_t buf_size,
+			       enum display_pixel_format fmt)
+{
+	uint8_t byte0, byte1, byte2;
+
+	if (fmt == PIXEL_FORMAT_BGR_888) {
+		byte0 = r;
+		byte1 = g;
+		byte2 = b;
+	} else { /* PIXEL_FORMAT_RGB_888 */
+		byte0 = b;
+		byte1 = g;
+		byte2 = r;
+	}
+
+	for (size_t idx = 0; idx < buf_size; idx += 3) {
+		*(buf + idx + 0) = byte0;
+		*(buf + idx + 1) = byte1;
+		*(buf + idx + 2) = byte2;
+	}
+}
+
+static void fill_buffer_rgb565(uint8_t r, uint8_t g, uint8_t b, uint8_t *buf, size_t buf_size,
+			       enum display_pixel_format fmt)
+{
+	/* shift the green an extra bit, it has 6 bits */
+	uint16_t color = ((uint16_t)r & 0x1Fu) << 11 | ((uint16_t)g & 0x1Fu) << (5 + 1) |
+			 ((uint16_t)b & 0x1Fu);
+
+	if (fmt == PIXEL_FORMAT_RGB_565) {
+		for (size_t idx = 0; idx < buf_size; idx += 2) {
+			*((uint16_t *)(buf + idx)) = sys_cpu_to_le16(color);
+		}
+	} else { /* PIXEL_FORMAT_RGB_565X */
+		for (size_t idx = 0; idx < buf_size; idx += 2) {
+			*(buf + idx + 0) = (color >> 8) & 0xFFu;
+			*(buf + idx + 1) = (color >> 0) & 0xFFu;
+		}
+	}
+}
+
+static void fill_buffer_al_88(uint8_t r, uint8_t g, uint8_t b, uint8_t *buf, size_t buf_size,
+			      enum display_pixel_format fmt)
+{
+	uint16_t word = 0xFF00u | fast_rgb2y(r, g, b);
+
+	for (size_t idx = 0; idx < buf_size; idx += 2) {
+		*((uint16_t *)(buf + idx)) = sys_cpu_to_le16(word);
+	}
+}
+
+static void fill_buffer_l_8(uint8_t r, uint8_t g, uint8_t b, uint8_t *buf, size_t buf_size,
+			    enum display_pixel_format fmt)
+{
+	uint8_t byte = 0x00u | fast_rgb2y(r, g, b);
+
+	for (size_t idx = 0; idx < buf_size; idx += 1) {
+		*(uint8_t *)(buf + idx) = byte;
+	}
+}
+
+static void fill_buffer_l_4(uint8_t r, uint8_t g, uint8_t b, uint8_t *buf, size_t buf_size,
+			    enum display_pixel_format fmt)
+{
+	uint8_t nibble = 0x0Fu & fast_rgb2y(r, g, b);
+	uint8_t byte = (nibble << 4) | nibble;
+
+	for (size_t idx = 0; idx < buf_size; idx += 1) {
+		*(uint8_t *)(buf + idx) = byte;
+	}
+}
+
+static void fill_buffer_mono(uint8_t r, uint8_t g, uint8_t b, uint8_t *buf, size_t buf_size,
+			     enum display_pixel_format fmt)
+{
+	uint8_t lumina = fast_rgb2y(r, g, b);
+	uint8_t byte;
+
+	if (fmt == PIXEL_FORMAT_MONO01) {
+		byte = (lumina & 0x01u) ? 0xFFu : 0x00u;
+	} else { /* PIXEL_FORMAT_MONO10 */
+		byte = (lumina & 0x01u) ? 0x00u : 0xFFu;
+	}
+
+	memset(buf, byte, buf_size);
+}
+
+static int write_lines_to_display(const struct device *const display, uint16_t lines,
+				  struct display_buffer_descriptor *buf_desc, const uint8_t *buf)
+{
+	int ret = 0;
+
+	/* This allows double-buffered displays to hold the pixels back
+	 * until the first image is complete.
+	 */
+	buf_desc->frame_incomplete = true;
+
+	for (int y = 0; y <= lines; ++y) {
+		/* With next (last) write the full frame is ready for output,
+		 * so turn this off. Double-buffered displays will then
+		 * present the new image to the user.
+		 */
+		if (y == lines) {
+			buf_desc->frame_incomplete = false;
+		}
+
+		ret = display_write(display, 0, y, buf_desc, buf);
+		if (ret < 0) {
+			break;
+		}
+	}
+
+	return ret;
+}
+
+int sample_colorful_draw(void)
+{
+	const struct device *display;
+	struct display_capabilities capabilities;
+	struct display_buffer_descriptor buf_desc;
+	uint8_t bg_ival;  /* background initial value */
+	uint8_t cg_mval;  /* color/gray maximum value */
+	uint16_t hlc_max; /* height line count maximum */
+	size_t buf_size = 0;
+	uint8_t *buf;
+	fill_buffer fill_buffer_fnc = NULL;
+	int32_t gradient_sleep;
+	size_t gradient_count = 0;
+	int ret = 0;
+
+	display = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+	if (!device_is_ready(display)) {
+		LOG_ERR("Device %s not found. Aborting sample.", display->name);
+		ret = -ENODEV;
+		goto end;
+	}
+
+	/* Hold a runtime PM reference so the display stays active for the
+	 * duration of the sample. No-op when runtime PM is not enabled on
+	 * the device.
+	 */
+	(void)pm_device_runtime_get(display);
+
+	display_get_capabilities(display, &capabilities);
+	LOG_INF("Colorful sample for %s", display->name);
+	LOG_INF("%s: %ux%u, pixel format: %u", display->name, capabilities.x_resolution,
+		capabilities.y_resolution, capabilities.current_pixel_format);
+
+	/* Screen is an Electrophoretic Display (ePaper). */
+	if (capabilities.screen_info & SCREEN_INFO_EPD) {
+		gradient_sleep = 10000;
+	} else {
+		gradient_sleep = 100;
+	}
+
+	switch (capabilities.current_pixel_format) {
+	case PIXEL_FORMAT_XRGB_8888:
+	case PIXEL_FORMAT_ARGB_8888:
+	case PIXEL_FORMAT_ABGR_8888:
+	case PIXEL_FORMAT_RGBA_8888:
+	case PIXEL_FORMAT_BGRA_8888:
+		/* True color space with alpha channel */
+		bg_ival = (uint8_t)(CONFIG_SAMPLE_INIT_INTENSITY);
+		cg_mval = (uint8_t)(CONFIG_SAMPLE_MAX_INTENSITY);
+		fill_buffer_fnc = fill_buffer_argb8888;
+		break;
+	case PIXEL_FORMAT_RGB_888:
+	case PIXEL_FORMAT_BGR_888:
+		/* True color space w/o alpha channel */
+		bg_ival = (uint8_t)(CONFIG_SAMPLE_INIT_INTENSITY);
+		cg_mval = (uint8_t)(CONFIG_SAMPLE_MAX_INTENSITY);
+		fill_buffer_fnc = fill_buffer_rgb888;
+		break;
+	case PIXEL_FORMAT_RGB_565:
+	case PIXEL_FORMAT_RGB_565X:
+		/* 64k color space (only 32k used with 5bit for green) */
+		bg_ival = (uint8_t)(CONFIG_SAMPLE_INIT_INTENSITY);
+		cg_mval = (uint8_t)((CONFIG_SAMPLE_MAX_INTENSITY) >> 3);
+		fill_buffer_fnc = fill_buffer_rgb565;
+		break;
+	case PIXEL_FORMAT_AL_88:
+		/* 256 grayscale with alpha channel */
+		bg_ival = (uint8_t)(CONFIG_SAMPLE_INIT_INTENSITY);
+		cg_mval = (uint8_t)(CONFIG_SAMPLE_MAX_INTENSITY);
+		fill_buffer_fnc = fill_buffer_al_88;
+		break;
+	case PIXEL_FORMAT_L_8:
+		/* 256 grayscale w/o alpha channel */
+		bg_ival = (uint8_t)(CONFIG_SAMPLE_INIT_INTENSITY);
+		cg_mval = (uint8_t)(CONFIG_SAMPLE_MAX_INTENSITY);
+		fill_buffer_fnc = fill_buffer_l_8;
+		break;
+	case PIXEL_FORMAT_L_4:
+		/* 16 grayscale w/o alpha channel */
+		bg_ival = (uint8_t)(CONFIG_SAMPLE_INIT_INTENSITY);
+		cg_mval = (uint8_t)(CONFIG_SAMPLE_MAX_INTENSITY & 0x0Fu);
+		fill_buffer_fnc = fill_buffer_l_4;
+		break;
+	case PIXEL_FORMAT_MONO01:
+		/* 1 bpp black/white with 0: black, 1: white */
+		bg_ival = (uint8_t)(CONFIG_SAMPLE_INIT_INTENSITY);
+		cg_mval = (uint8_t)(CONFIG_SAMPLE_MAX_INTENSITY);
+		fill_buffer_fnc = fill_buffer_mono;
+		break;
+	case PIXEL_FORMAT_MONO10:
+		/* 1 bpp black/white with 1: black, 0: white */
+		bg_ival = (uint8_t)(~(CONFIG_SAMPLE_INIT_INTENSITY));
+		cg_mval = (uint8_t)(CONFIG_SAMPLE_MAX_INTENSITY);
+		fill_buffer_fnc = fill_buffer_mono;
+		break;
+	default:
+		LOG_ERR("Unsupported pixel format. Aborting sample.");
+		ret = -ENOTSUP;
+		goto end;
+	}
+
+	/* hold only one single line at once in application buffer on heap */
+	buf_size = capabilities.x_resolution;
+
+	/* Amount of bytes necessary depends on format - ensure to round up, necessary for
+	 * MONO formats
+	 */
+	buf_size *= DISPLAY_BITS_PER_PIXEL(capabilities.current_pixel_format);
+	buf_size = DIV_ROUND_UP(DIV_ROUND_UP(buf_size, NUM_BITS(uint8_t)), sizeof(uint8_t));
+
+	buf = k_aligned_alloc(CONFIG_SAMPLE_BUFFER_ADDR_ALIGN, buf_size);
+
+	if (buf == NULL) {
+		LOG_ERR("Could not allocate memory (%zu byte). Aborting sample.", buf_size);
+		ret = -ENOMEM;
+		goto end;
+	}
+
+	LOG_INF("%s: allocated memory: %zu", display->name, buf_size);
+	(void)memset(buf, bg_ival, buf_size);
+
+	buf_desc.buf_size = buf_size;
+	buf_desc.pitch = capabilities.x_resolution;
+	buf_desc.width = capabilities.x_resolution;
+	buf_desc.height = 1;
+	hlc_max = capabilities.y_resolution - buf_desc.height;
+
+	ret = write_lines_to_display(display, hlc_max, &buf_desc, buf);
+	if (ret < 0) {
+		LOG_ERR("Failed to write to display (error %d)", ret);
+		goto end;
+	}
+
+	ret = display_blanking_off(display);
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Failed to turn blanking off (error %d)", ret);
+		goto end;
+	}
+
+	LOG_INF("Colorful starts");
+	while (1) {
+		/* Red -> Green Gradient */
+		for (int i = 0; i <= cg_mval; ++i) {
+			uint8_t r = cg_mval - i;
+			uint8_t g = i;
+			uint8_t b = 0;
+
+			fill_buffer_fnc(r, g, b, buf, buf_size, capabilities.current_pixel_format);
+			ret = write_lines_to_display(display, hlc_max, &buf_desc, buf);
+			if (ret < 0) {
+				LOG_ERR("Failed to write to display (error %d)", ret);
+				goto end;
+			}
+
+			k_msleep(gradient_sleep);
+		}
+
+		/* Green -> Blue Gradient */
+		for (int i = 0; i <= cg_mval; ++i) {
+			uint8_t g = cg_mval - i;
+			uint8_t b = i;
+			uint8_t r = 0;
+
+			fill_buffer_fnc(r, g, b, buf, buf_size, capabilities.current_pixel_format);
+			ret = write_lines_to_display(display, hlc_max, &buf_desc, buf);
+			if (ret < 0) {
+				LOG_ERR("Failed to write to display (error %d)", ret);
+				goto end;
+			}
+
+			k_msleep(gradient_sleep);
+		}
+
+		/* Blue -> Red Gradient */
+		for (int i = 0; i <= cg_mval; ++i) {
+			uint8_t b = cg_mval - i;
+			uint8_t r = i;
+			uint8_t g = 0;
+
+			fill_buffer_fnc(r, g, b, buf, buf_size, capabilities.current_pixel_format);
+			ret = write_lines_to_display(display, hlc_max, &buf_desc, buf);
+			if (ret < 0) {
+				LOG_ERR("Failed to write to display (error %d)", ret);
+				goto end;
+			}
+
+			k_msleep(gradient_sleep);
+		}
+
+		++gradient_count;
+#if CONFIG_TEST
+		if (gradient_count >= 3) {
+			LOG_INF("Colorful sample test mode done %s", display->name);
+			break;
+		}
+#endif
+	}
+
+end:
+#if CONFIG_TEST
+	if (ret == 0) {
+		LOG_INF("PROJECT EXECUTION SUCCESSFUL");
+	} else {
+		LOG_INF("PROJECT EXECUTION FAILED");
+	}
+#endif
+#ifdef CONFIG_ARCH_POSIX
+	posix_exit(ret == 0 ? 0 : 1);
+#endif
+	return 0;
+}

--- a/samples/display/colorful/src/colorful.h
+++ b/samples/display/colorful/src/colorful.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on Zephyr upstream display driver sample:
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ * Copyright (c) 2025 NXP
+ */
+
+#ifndef __SAMPLE_COLORFUL_H__
+#define __SAMPLE_COLORFUL_H__
+
+int sample_colorful_draw(void);
+
+#endif /* __SAMPLE_COLORFUL_H__ */

--- a/samples/display/colorful/src/main.c
+++ b/samples/display/colorful/src/main.c
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on Zephyr upstream display driver sample:
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ * Copyright (c) 2025 NXP
+ */
+
+#include "colorful.h"
+
+int main(void)
+{
+	return sample_colorful_draw();
+}

--- a/samples/display/colorful/tests.yaml
+++ b/samples/display/colorful/tests.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  description: Draw an RGB color gradient on a display device.
+  name: colorful
+common:
+  tags:
+    - bridle
+    - display
+    - drivers
+tests:
+  sample.display.colorful.sdl:
+    build_only: true
+    platform_allow:
+      - native_sim/native/64
+  sample.display.colorful.dummy:
+    platform_allow:
+      - native_sim
+      - qemu_x86
+    extra_args: DTC_OVERLAY_FILE="dummy_dc.overlay"
+    extra_configs:
+      - CONFIG_SDL_DISPLAY=n
+      - CONFIG_TEST=y
+    harness: console
+    harness_config:
+      fixture: fixture_display
+      type: multi_line
+      regex:
+        - "Colorful sample for (.*)"
+        - "(.*): 320x240, pixel format: 8"
+        - "(.*): allocated memory: 1280"
+        - "Colorful starts"
+        - "Colorful sample test mode done (.*)"
+  sample.display.colorful.builtin:
+    # This test case is intended to insure that this sample builds & runs
+    # correctly for all boards that have a supported built-in display.
+    filter: dt_chosen_enabled("zephyr,display")
+    harness: console
+    harness_config:
+      fixture: fixture_display
+      type: multi_line
+      regex:
+        - "Colorful sample for (.*)"
+        - "Colorful starts"
+  sample.display.colorful.shield:
+    # This test case is intended to verify support for shields on boards
+    # known to support them. It is not intended to cover all combinations
+    # of boards and shields, but rather serve as a method to test each
+    # display shield within Zephyr
+    filter: dt_chosen_enabled("zephyr,display")
+    harness: console
+    harness_config:
+      fixture: fixture_display
+      type: multi_line
+      regex:
+        - "Colorful sample for (.*)"
+        - "Colorful starts"
+    extra_args:
+      - platform:lpcxpresso55s69/lpc55s69/cpu0:SHIELD=adafruit_2_8_tft_touch_v2
+      - platform:mimxrt685_evk/mimxrt685/cm33:SHIELD=waveshare_epaper_gdeh0213b1
+      - platform:nucleo_l433rc_p/stm32l433xx:SHIELD=waveshare_epaper_gdew042t2
+      - platform:nrf52dk/nrf52832:SHIELD=st7789v_tl019fqv01
+      - platform:mimxrt1010_evk/mimxrt1011:SHIELD=st7789v_waveshare_240x240
+      - platform:frdm_k22f/mk22f51212:SHIELD=ls013b7dh03
+      - platform:nrf52833dk/nrf52833:SHIELD=st7735r_ada_160x128
+      - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
+      - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:SHIELD=rk055hdmipi4ma0
+      - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:SHIELD=zc143ac72mipi
+      - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:SHIELD=lcd_par_s035_8080
+      - platform:da1469x_dk_pro/da14699:DTC_OVERLAY_FILE=da1469x_dk_pro_mipi_dbi.overlay
+      - platform:nrf52840dk/nrf52840:SHIELD=max7219_8x8
+      - platform:stm32h747i_disco/stm32h747xx/m7:SHIELD=st_b_lcd40_dsi1_mb1166
+      - platform:mimxrt1064_evk/mimxrt1064:SHIELD=rk043fn66hs_ctg
+      - platform:mimxrt1060_evk/mimxrt1062:SHIELD=rk043fn66hs_ctg
+      - platform:mimxrt1050_evk/mimxrt1052:SHIELD=rk043fn66hs_ctg
+      - platform:mimxrt1040_evk/mimxrt1042:SHIELD=rk043fn66hs_ctg
+      - platform:frdm_mcxn947/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
+      - platform:mcx_n9xx_evk/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
+      - platform:mcx_n5xx_evk/mcxn547/cpu0:SHIELD=lcd_par_s035_8080
+      - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
+      - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
+      - platform:frdm_mcxa577:SHIELD=lcd_par_s035_8080
+      - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi
+      - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be
+      - platform:ek_ra8d1:SHIELD=rtk7eka6m3b00001bu
+      - platform:nucleo_g071rb/stm32g071xx:SHIELD=x_nucleo_gfx01m2
+      - platform:m5stack_atoms3/esp32s3/procpu:SHIELD=m5stack_unit_minioled


### PR DESCRIPTION
Adds an alternative sample for using multiple display drivers with different pixel formats and color modells. It renders an colorful RGB gradient on standard LCD, OLED or LED (strip) matrix displays and grayscale gradient on monochrome displays or EPD (ePaper).